### PR TITLE
feat: add context manager capability to subscriber

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -228,3 +228,19 @@ class Client(object):
         manager.open(callback=callback, on_callback_error=future.set_exception)
 
         return future
+
+    def close(self):
+        """Close the underlying channel to release socket resources.
+
+        After a channel has been closed, the client instance cannot be used
+        anymore.
+
+        This method is idempotent.
+        """
+        self.api.transport.channel.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,7 +110,7 @@ def system(session):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install("mock", "pytest")
+    session.install("mock", "pytest", "psutil")
 
     session.install("-e", "test_utils")
     session.install("-e", ".")

--- a/tests/system.py
+++ b/tests/system.py
@@ -18,6 +18,7 @@ import datetime
 import itertools
 import operator as op
 import os
+import psutil
 import threading
 import time
 
@@ -46,7 +47,7 @@ def publisher():
     yield pubsub_v1.PublisherClient()
 
 
-@pytest.fixture(scope=u"module")
+@pytest.fixture()
 def subscriber():
     yield pubsub_v1.SubscriberClient()
 
@@ -381,6 +382,50 @@ def test_managing_subscription_iam_policy(
 
     assert bindings[1].role == "roles/pubsub.viewer"
     assert bindings[1].members == ["group:cloud-logs@google.com"]
+
+
+def test_subscriber_not_leaking_open_sockets(
+    publisher, topic_path, subscriber, subscription_path, cleanup
+):
+    # Make sure the topic and the supscription get deleted.
+    # NOTE: Since `subscriber` will be closed in the test, we need another
+    # subscriber to clean up the subscription.
+    # Also, we need to make sure that auxiliary subscriber releases the sockets, too.
+    subscriber_2 = pubsub_v1.SubscriberClient()
+    cleanup.append((subscriber_2.delete_subscription, subscription_path))
+
+    def one_arg_close(subscriber):  # the cleanup helper expects exactly one argument
+        subscriber.close()
+
+    cleanup.append((one_arg_close, subscriber_2))
+    cleanup.append((publisher.delete_topic, topic_path))
+
+    # Create topic before starting to track connection count (any sockets opened
+    # by the publisher client are not counted by this test).
+    publisher.create_topic(topic_path)
+
+    current_process = psutil.Process()
+    conn_count_start = len(current_process.connections())
+
+    # Publish a few messages, then synchronously pull them and check that
+    # no sockets are leaked.
+    with subscriber:
+        subscriber.create_subscription(name=subscription_path, topic=topic_path)
+
+        # Publish a few messages, wait for the publish to succeed.
+        publish_futures = [
+            publisher.publish(topic_path, u"message {}".format(i).encode())
+            for i in range(1, 4)
+        ]
+        for future in publish_futures:
+            future.result()
+
+        # Synchronously pull messages.
+        response = subscriber.pull(subscription_path, max_messages=3)
+        assert len(response.received_messages) == 3
+
+    conn_count_end = len(current_process.connections())
+    assert conn_count_end == conn_count_start
 
 
 class TestStreamingPull(object):

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -106,3 +106,22 @@ def test_subscribe_options(manager_open):
         callback=mock.sentinel.callback,
         on_callback_error=future.set_exception,
     )
+
+
+def test_close():
+    mock_transport = mock.NonCallableMock()
+    client = subscriber.Client(transport=mock_transport)
+
+    client.close()
+
+    mock_transport.channel.close.assert_called()
+
+
+def test_closes_channel_as_context_manager():
+    mock_transport = mock.NonCallableMock()
+    client = subscriber.Client(transport=mock_transport)
+
+    with client:
+        pass
+
+    mock_transport.channel.close.assert_called()


### PR DESCRIPTION
Fixes #4.

This PR gives users a more handy way of closing the subscriber's underlying channel.

### How to test
-  Make sure that a topic has a few messages published to it to avoid the issue with a dubious `DeadlineExceeded` response.
- List the currently open sockets by Python:
    ```
    $ lsof -i -n | grep python
    ```
- Run the code snippet from the ticket description in debugger, but by using the subscriber client as a context manager:
    ```py
    with subscriber:
        ...
    ```
    Make sure to place a breakpoint after the `with` block.
- After the messages have been pulled and the context manager exited, list the open sockets again.

**Actual result (before the fix):**
Subscriber client cannot be used as a context manager. Using it without the context results in open sockets being leaked until the Python process terminates,

**Expected result (after the fix):**
Subscriber client releases the open sockes after exiting the context management block.

### Things to consider/discuss
 - I experimented by adding a `_close` flag to the client and additional logic that would raise an error if any of its methods are used after the client has been closed. Since a lot of the methods are copied from the generated `SubscriberClient` GAPIC class, that extra logic would bloat the code without that much of a gain (the GRPC channel itself already raises an informative "channel closed" error).
 - I did not implement the `__del__()` method that would call `close()` automatically, as this could bring its own set of potential problems.
 - While already at it, should we add similar logic to the publisher client, too? The latter, too, opens two sockets through its underlying GRPC channel.
 - Update code samples in docs to demonstrate the context manager capability as a recommended practice?

### PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)


