### PR TITLE
fix: shutdown error on streaming pull callback error

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -33,6 +33,11 @@ class StreamingPullFuture(futures.Future):
         self._cancelled = False
 
     def _on_close_callback(self, manager, result):
+        if self.done():
+            # The future has already been resolved in a different thread,
+            # nothing to do on the streaming pull manager shutdown.
+            return
+
         if result is None:
             self.set_result(True)
         else:

--- a/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -57,6 +57,18 @@ class TestStreamingPullFuture(object):
 
         assert not future.running()
 
+    def test__on_close_callback_future_already_done(self):
+        future = self.make_future()
+
+        future.set_result("foo")
+        assert future.done()
+
+        # invoking on close callback should result in an error
+        future._on_close_callback(mock.sentinel.manager, "bar")
+
+        result = future.result()
+        assert result == "foo"  # on close callback was a no-op
+
     def test_cancel(self):
         future = self.make_future()
 

--- a/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -63,7 +63,7 @@ class TestStreamingPullFuture(object):
         future.set_result("foo")
         assert future.done()
 
-        # invoking on close callback should result in an error
+        # invoking on close callback should not result in an error
         future._on_close_callback(mock.sentinel.manager, "bar")
 
         result = future.result()


### PR DESCRIPTION
Fixes #39.

This PR fixes an error that can happen if cancelling a streaming pull future when the streaming pull manager has already been shut down due to the error in the user callback.

### How to test

- Have a topic and a subscription, publish at least one message to the topic.
- Take the basic [streaming pull sample](https://cloud.google.com/pubsub/docs/pull#asynchronous-pull) from the docs.
- Adjust the message received callback to raise an exception

**Actual result (before the fix):**
An error occurs during the shutdown:
```
RuntimeError: set_result can only be called once.
```

**Expected result (after the fix):**
No internal error occurs during the shutdown, except for the error from the user callback, as expected.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


