### PR TITLE
fix: don't assert on unordered publishes after publish error

### DIFF
--- a/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -369,3 +369,6 @@ class Batch(base.Batch):
             self.commit()
 
         return future
+
+    def _set_status(self, status):
+        self._status = status

--- a/google/cloud/pubsub_v1/publisher/_sequencer/unordered_sequencer.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/unordered_sequencer.py
@@ -65,6 +65,12 @@ class UnorderedSequencer(base.Sequencer):
         if self._current_batch:
             self._current_batch.commit()
 
+            # At this point, we lose track of the old batch, but we don't
+            # care since we just committed it.
+            # Setting this to None guarantees the next publish() creates a new
+            # batch.
+            self._current_batch = None
+
     def unpause(self):
         """ Not relevant for this class. """
         raise NotImplementedError

--- a/tests/unit/pubsub_v1/publisher/sequencer/test_unordered_sequencer.py
+++ b/tests/unit/pubsub_v1/publisher/sequencer/test_unordered_sequencer.py
@@ -18,6 +18,7 @@ import pytest
 from google.auth import credentials
 from google.cloud.pubsub_v1 import publisher
 from google.cloud.pubsub_v1 import types
+from google.cloud.pubsub_v1.publisher._batch import base
 from google.cloud.pubsub_v1.publisher._sequencer import unordered_sequencer
 
 
@@ -101,4 +102,24 @@ def test_publish_batch_full():
     # Will create a new batch since the old one is full, and return a future.
     future = sequencer.publish(message)
     batch.publish.assert_called_once_with(message)
+    assert future is not None
+
+
+def test_publish_after_batch_error():
+    client = create_client()
+    message = create_message()
+    batch = mock.Mock(spec=client._batch_class)
+
+    sequencer = unordered_sequencer.UnorderedSequencer(client, "topic_name")
+    sequencer._set_batch(batch)
+
+    sequencer.commit()
+    batch.commit.assert_called_once()
+
+    # Simulate publish RPC failing.
+    batch._set_status(base.BatchStatus.ERROR)
+
+    # Will create a new batch since the old one has been committed. The fact
+    # that it errored should not matter in the publish of the next message.
+    future = sequencer.publish(message)
     assert future is not None

--- a/tests/unit/pubsub_v1/publisher/sequencer/test_unordered_sequencer.py
+++ b/tests/unit/pubsub_v1/publisher/sequencer/test_unordered_sequencer.py
@@ -120,6 +120,7 @@ def test_publish_after_batch_error():
     batch._set_status(base.BatchStatus.ERROR)
 
     # Will create a new batch since the old one has been committed. The fact
-    # that it errored should not matter in the publish of the next message.
+    # that the old batch errored should not matter in the publish of the next
+    # message.
     future = sequencer.publish(message)
     assert future is not None


### PR DESCRIPTION
Unordered batches that threw errors on invoking the publish RPC led to subsequent assertion failures in thread.py::publish(). These assertion failures were legitimate. Publish calls should not be called on batches that have already been committed. (In this case, they were committed and then returned an error.)

This pull request fixes the underlying issue by clearing out the UnorderedSequencer's _current_batch on commit(). This ensures that no subsequent publish() calls will be called on that batch since the reference to it is lost.

I add a new "test_publish_after_batch_error" test for this scenario.

The OrderedSequencer does not have this issue. On error, it cancels all batches and pauses the ordering key. The existing "test_batch_done_unsuccessfully" test captures this scenario.

Fixes #48