### PR TITLE
fix: use client_options.api_endpoint parameter instead of ignoring it

### DIFF
--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -133,6 +133,12 @@ class Client(object):
                 target=os.environ.get("PUBSUB_EMULATOR_HOST")
             )
 
+        client_options = kwargs.pop("client_options", None)
+        if client_options and type(client_options["api_endpoint"]) is str:
+            self._target = client_options["api_endpoint"]
+        else:
+            self._target = publisher_client.PublisherClient.SERVICE_ADDRESS
+
         # Use a custom channel.
         # We need this in order to set appropriate default message size and
         # keepalive options.
@@ -217,7 +223,7 @@ class Client(object):
         Returns:
             str: The location of the API.
         """
-        return publisher_client.PublisherClient.SERVICE_ADDRESS
+        return self._target
 
     def _get_or_create_sequencer(self, topic, ordering_key):
         """ Get an existing sequencer or create a new one given the (topic,

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -134,7 +134,11 @@ class Client(object):
             )
 
         client_options = kwargs.pop("client_options", None)
-        if client_options and type(client_options["api_endpoint"]) is str:
+        if (
+            client_options
+            and "api_endpoint" in client_options
+            and isinstance(client_options["api_endpoint"], six.string_types)
+        ):
             self._target = client_options["api_endpoint"]
         else:
             self._target = publisher_client.PublisherClient.SERVICE_ADDRESS

--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -79,6 +79,13 @@ class Client(object):
                 target=os.environ.get("PUBSUB_EMULATOR_HOST")
             )
 
+        # api_endpoint wont be applied if 'transport' is passed in.
+        client_options = kwargs.pop("client_options", None)
+        if client_options and type(client_options["api_endpoint"]) is str:
+            self._target = client_options["api_endpoint"]
+        else:
+            self._target = subscriber_client.SubscriberClient.SERVICE_ADDRESS
+
         # Use a custom channel.
         # We need this in order to set appropriate default message size and
         # keepalive options.
@@ -133,7 +140,7 @@ class Client(object):
         Returns:
             str: The location of the API.
         """
-        return subscriber_client.SubscriberClient.SERVICE_ADDRESS
+        return self._target
 
     @property
     def api(self):

--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 import os
 import pkg_resources
+import six
 
 import grpc
 
@@ -81,7 +82,11 @@ class Client(object):
 
         # api_endpoint wont be applied if 'transport' is passed in.
         client_options = kwargs.pop("client_options", None)
-        if client_options and type(client_options["api_endpoint"]) is str:
+        if (
+            client_options
+            and "api_endpoint" in client_options
+            and isinstance(client_options["api_endpoint"], six.string_types)
+        ):
             self._target = client_options["api_endpoint"]
         else:
             self._target = subscriber_client.SubscriberClient.SERVICE_ADDRESS

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -53,6 +53,16 @@ def test_init_w_custom_transport():
     assert client.batch_settings.max_messages == 100
 
 
+def test_init_w_api_endpoint():
+    client_options = {"api_endpoint": "testendpoint.google.com"}
+    client = publisher.Client(client_options=client_options)
+
+    assert isinstance(client.api, publisher_client.PublisherClient)
+    assert (client.api.transport._channel._channel.target()).decode(
+        "utf-8"
+    ) == "testendpoint.google.com"
+
+
 def test_init_emulator(monkeypatch):
     monkeypatch.setenv("PUBSUB_EMULATOR_HOST", "/foo/bar/")
     # NOTE: When the emulator host is set, a custom channel will be used, so

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -63,6 +63,25 @@ def test_init_w_api_endpoint():
     ) == "testendpoint.google.com"
 
 
+def test_init_w_unicode_api_endpoint():
+    client_options = {"api_endpoint": u"testendpoint.google.com"}
+    client = publisher.Client(client_options=client_options)
+
+    assert isinstance(client.api, publisher_client.PublisherClient)
+    assert (client.api.transport._channel._channel.target()).decode(
+        "utf-8"
+    ) == "testendpoint.google.com"
+
+
+def test_init_w_empty_client_options():
+    client = publisher.Client(client_options={})
+
+    assert isinstance(client.api, publisher_client.PublisherClient)
+    assert (client.api.transport._channel._channel.target()).decode(
+        "utf-8"
+    ) == publisher_client.PublisherClient.SERVICE_ADDRESS
+
+
 def test_init_emulator(monkeypatch):
     monkeypatch.setenv("PUBSUB_EMULATOR_HOST", "/foo/bar/")
     # NOTE: When the emulator host is set, a custom channel will be used, so

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -44,6 +44,25 @@ def test_init_w_api_endpoint():
     ) == "testendpoint.google.com"
 
 
+def test_init_w_unicode_api_endpoint():
+    client_options = {"api_endpoint": u"testendpoint.google.com"}
+    client = subscriber.Client(client_options=client_options)
+
+    assert isinstance(client.api, subscriber_client.SubscriberClient)
+    assert (client.api.transport._channel._channel.target()).decode(
+        "utf-8"
+    ) == "testendpoint.google.com"
+
+
+def test_init_w_empty_client_options():
+    client = subscriber.Client(client_options={})
+
+    assert isinstance(client.api, subscriber_client.SubscriberClient)
+    assert (client.api.transport._channel._channel.target()).decode(
+        "utf-8"
+    ) == subscriber_client.SubscriberClient.SERVICE_ADDRESS
+
+
 def test_init_emulator(monkeypatch):
     monkeypatch.setenv("PUBSUB_EMULATOR_HOST", "/baz/bacon/")
     # NOTE: When the emulator host is set, a custom channel will be used, so

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -34,6 +34,16 @@ def test_init_w_custom_transport():
     assert client.api.transport is transport
 
 
+def test_init_w_api_endpoint():
+    client_options = {"api_endpoint": "testendpoint.google.com"}
+    client = subscriber.Client(client_options=client_options)
+
+    assert isinstance(client.api, subscriber_client.SubscriberClient)
+    assert (client.api.transport._channel._channel.target()).decode(
+        "utf-8"
+    ) == "testendpoint.google.com"
+
+
 def test_init_emulator(monkeypatch):
     monkeypatch.setenv("PUBSUB_EMULATOR_HOST", "/baz/bacon/")
     # NOTE: When the emulator host is set, a custom channel will be used, so


### PR DESCRIPTION
- The client_options.api-endpoint parameter was being ignored. This bug prevented users from using regional endpoints. It also made it harder to test code against nonprod endpoints.

Fixes #61