### PR TITLE
fix: restrict api-core dependency to < 1.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,10 @@ version = "1.4.2"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    # google-api-core[grpc] 1.17.0 causes problems, thus restricting its
+    # version until the issue gets fixed.
+    # https://github.com/googleapis/python-pubsub/issues/74
+    "google-api-core[grpc] >= 1.14.0, < 1.17.0",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]


### PR DESCRIPTION
Fixes #74 
Fixes #75.

The `google-api-core` version 1.17.0 released yesterday causes problems on re-establishing message streams on retryable errors, thus restricting it.

To test, make a fresh installation of the the pubsub client with and without this version pin change, and try to reproduce the issue as described.

Tip: Deadline Exceeded errors can be triggered by temporarily disable internet connection on the local machine, and then re-enable it to see if the stream is re-established.

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


