### PR TITLE
feat: add flow control for message publishing

### DIFF
--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -343,11 +343,6 @@ class Client(object):
 
             pubsub_v1.publisher.exceptions.MessageTooLargeError: If publishing
                 the ``message`` would exceed the max size limit on the backend.
-
-            :exception:`~pubsub_v1.publisher.exceptions.FlowControlLimitError`:
-                If publishing a new message would exceed the publish flow control
-                limits and the desired action on overflow is
-                :attr:`~google.cloud.pubsub_v1.types.LimitExceededBehavior.ERROR`.
         """
         # Sanity check: Is the data being sent as a bytestring?
         # If it is literally anything else, complain loudly about it.

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -34,6 +34,7 @@ from google.cloud.pubsub_v1.gapic.transports import publisher_grpc_transport
 from google.cloud.pubsub_v1.publisher._batch import thread
 from google.cloud.pubsub_v1.publisher._sequencer import ordered_sequencer
 from google.cloud.pubsub_v1.publisher._sequencer import unordered_sequencer
+from google.cloud.pubsub_v1.publisher.flow_controller import FlowController
 
 __version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
 
@@ -93,7 +94,11 @@ class Client(object):
 
             # Optional
             publisher_options = pubsub_v1.types.PublisherOptions(
-                enable_message_ordering=False
+                enable_message_ordering=False,
+                flow_control=pubsub_v1.types.PublishFlowControl(
+                    message_limit=2000,
+                    limit_exceeded_behavior=pubsub_v1.types.LimitExceededBehavior.BLOCK,
+                ),
             ),
 
             # Optional
@@ -197,6 +202,9 @@ class Client(object):
         self._is_stopped = False
         # Thread created to commit all sequencers after a timeout.
         self._commit_thread = None
+
+        # The object controlling the message publishing flow
+        self._flow_controller = FlowController(self.publisher_options.flow_control)
 
     @classmethod
     def from_service_account_file(cls, filename, batch_settings=(), **kwargs):
@@ -333,6 +341,11 @@ class Client(object):
 
             pubsub_v1.publisher.exceptions.MessageTooLargeError: If publishing
                 the ``message`` would exceed the max size limit on the backend.
+
+            :exception:`~pubsub_v1.publisher.exceptions.FlowControlLimitError`:
+                If publishing a new message would exceed the publish flow control
+                limits and the desired action on overflow is
+                :attr:`~google.cloud.pubsub_v1.types.LimitExceededBehavior.ERROR`.
         """
         # Sanity check: Is the data being sent as a bytestring?
         # If it is literally anything else, complain loudly about it.
@@ -364,6 +377,13 @@ class Client(object):
             data=data, ordering_key=ordering_key, attributes=attrs
         )
 
+        # Messages should go through flow control to prevent excessive
+        # queuing on the client side (depending on the settings).
+        self._flow_controller.add(message)
+
+        def on_publish_done(future):
+            self._flow_controller.release(message)
+
         with self._batch_lock:
             if self._is_stopped:
                 raise RuntimeError("Cannot publish on a stopped publisher.")
@@ -372,6 +392,7 @@ class Client(object):
 
             # Delegate the publishing to the sequencer.
             future = sequencer.publish(message)
+            future.add_done_callback(on_publish_done)
 
             # Create a timer thread if necessary to enforce the batching
             # timeout.

--- a/google/cloud/pubsub_v1/publisher/exceptions.py
+++ b/google/cloud/pubsub_v1/publisher/exceptions.py
@@ -42,6 +42,10 @@ class FlowControlLimitError(Exception):
     """An action resulted in exceeding the flow control limits."""
 
 
+class PermanentlyBlockedError(FlowControlLimitError):
+    """A message exceeds *total* flow control limits and would block forever."""
+
+
 __all__ = (
     "FlowControlLimitError",
     "MessageTooLargeError",

--- a/google/cloud/pubsub_v1/publisher/exceptions.py
+++ b/google/cloud/pubsub_v1/publisher/exceptions.py
@@ -42,10 +42,6 @@ class FlowControlLimitError(Exception):
     """An action resulted in exceeding the flow control limits."""
 
 
-class PermanentlyBlockedError(FlowControlLimitError):
-    """A message exceeds *total* flow control limits and would block forever."""
-
-
 __all__ = (
     "FlowControlLimitError",
     "MessageTooLargeError",

--- a/google/cloud/pubsub_v1/publisher/exceptions.py
+++ b/google/cloud/pubsub_v1/publisher/exceptions.py
@@ -38,7 +38,12 @@ class PublishToPausedOrderingKeyException(Exception):
         super(PublishToPausedOrderingKeyException, self).__init__()
 
 
+class FlowControlLimitError(Exception):
+    """An action resulted in exceeding the flow control limits."""
+
+
 __all__ = (
+    "FlowControlLimitError",
     "MessageTooLargeError",
     "PublishError",
     "TimeoutError",

--- a/google/cloud/pubsub_v1/publisher/flow_controller.py
+++ b/google/cloud/pubsub_v1/publisher/flow_controller.py
@@ -201,8 +201,16 @@ class FlowController(object):
 
             reservation = self._byte_reservations[thread]
             still_needed = reservation.needed - reservation.reserved
-            can_give = min(still_needed, available)
 
+            # Sanity check for any internal inconsistencies.
+            if still_needed < 0:
+                msg = "Too many bytes reserved: {} / {}".format(
+                    reservation.reserved, reservation.needed
+                )
+                warnings.warn(msg, category=RuntimeWarning)
+                still_needed = 0
+
+            can_give = min(still_needed, available)
             reservation.reserved += can_give
             self._reserved_bytes += can_give
             available -= can_give

--- a/google/cloud/pubsub_v1/publisher/flow_controller.py
+++ b/google/cloud/pubsub_v1/publisher/flow_controller.py
@@ -76,12 +76,11 @@ class FlowController(object):
 
         Raises:
             :exception:`~pubsub_v1.publisher.exceptions.FlowControlLimitError`:
-                If adding a message would exceed flow control limits and the desired
-                action is :attr:`~google.cloud.pubsub_v1.types.LimitExceededBehavior.ERROR`,
-                or if a message would always exceed total flow control limits on
-                its own and the desired action is
-                :attr:`~google.cloud.pubsub_v1.types.LimitExceededBehavior.BLOCK`,
-                meaning that the message would block forever.
+                Raised when the desired action is
+                :attr:`~google.cloud.pubsub_v1.types.LimitExceededBehavior.ERROR` and
+                the message would exceed flow control limits, or when the desired action
+                is :attr:`~google.cloud.pubsub_v1.types.LimitExceededBehavior.BLOCK` and
+                the message would block forever against the flow control limits.
         """
         if self._settings.limit_exceeded_behavior == types.LimitExceededBehavior.IGNORE:
             return

--- a/google/cloud/pubsub_v1/publisher/flow_controller.py
+++ b/google/cloud/pubsub_v1/publisher/flow_controller.py
@@ -149,16 +149,12 @@ class FlowController(object):
                     "{}.".format(self._load_info())
                 )
 
-            # Message accepted, increase the load and remove thread stats if
-            # they exist in the waiting queue.
+            # Message accepted, increase the load and remove thread stats.
             self._message_count += 1
             self._total_bytes += message.ByteSize()
-
-            reservation = self._byte_reservations.get(current_thread)
-            if reservation:
-                self._reserved_bytes -= reservation.reserved
-                del self._byte_reservations[current_thread]
-                self._waiting.remove(current_thread)
+            self._reserved_bytes -= self._byte_reservations[current_thread].reserved
+            del self._byte_reservations[current_thread]
+            self._waiting.remove(current_thread)
 
     def release(self, message):
         """Release a mesage from flow control.

--- a/google/cloud/pubsub_v1/publisher/flow_controller.py
+++ b/google/cloud/pubsub_v1/publisher/flow_controller.py
@@ -1,0 +1,145 @@
+# Copyright 2020, Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import threading
+import warnings
+
+from google.cloud.pubsub_v1 import types
+from google.cloud.pubsub_v1.publisher import exceptions
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FlowController(object):
+    """A class used to control the flow of messages passing through it.
+
+    Args:
+        settings (~google.cloud.pubsub_v1.types.PublishFlowControl):
+            Desired flow control configuration.
+    """
+
+    def __init__(self, settings):
+        self._settings = settings
+
+        self._message_count = 0
+        self._total_bytes = 0
+
+        # The lock is used to protect the internal state (message and byte count).
+        self._operational_lock = threading.Lock()
+
+        # The condition for blocking the flow if capacity is exceeded.
+        self._has_capacity = threading.Condition(lock=self._operational_lock)
+
+    def add(self, message):
+        """Add a message to flow control.
+
+        Adding a message updates the internal load statistics, and an action is
+        taken if these limits are exceeded (depending on the flow control settings).
+
+        Args:
+            message (:class:`~google.cloud.pubsub_v1.types.PubsubMessage`):
+                The message entering the flow control.
+
+        Raises:
+            :exception:`~pubsub_v1.publisher.exceptions.FlowControlLimitError`:
+                If adding a message exceeds flow control limits and the desired
+                action is :attr:`~google.cloud.pubsub_v1.types.LimitExceededBehavior.ERROR`.
+        """
+        if self._settings.limit_exceeded_behavior == types.LimitExceededBehavior.IGNORE:
+            return
+
+        with self._operational_lock:
+            self._message_count += 1
+            self._total_bytes += message.ByteSize()
+
+            if not self._is_overflow():
+                return
+
+            # We have an overflow, react.
+            if (
+                self._settings.limit_exceeded_behavior
+                == types.LimitExceededBehavior.ERROR
+            ):
+                msg = (
+                    "Flow control limits exceeded "
+                    "(messages: {} / {}, bytes: {} / {})."
+                ).format(
+                    self._message_count,
+                    self._settings.message_limit,
+                    self._total_bytes,
+                    self._settings.byte_limit,
+                )
+                error = exceptions.FlowControlLimitError(msg)
+
+                # Raising an error means rejecting a message, thus we need to deduct
+                # the latter's contribution to the total load.
+                self._message_count -= 1
+                self._total_bytes -= message.ByteSize()
+                raise error
+
+            assert (
+                self._settings.limit_exceeded_behavior
+                == types.LimitExceededBehavior.BLOCK
+            )
+
+            while self._is_overflow():
+                _LOGGER.debug(
+                    "Blocking until there is enough free capacity in the flow."
+                )
+                self._has_capacity.wait()
+                _LOGGER.debug("Woke up from waiting on free capacity in the flow.")
+
+    def release(self, message):
+        """Release a mesage from flow control.
+
+        Args:
+            message (:class:`~google.cloud.pubsub_v1.types.PubsubMessage`):
+                The message entering the flow control.
+        """
+        if self._settings.limit_exceeded_behavior == types.LimitExceededBehavior.IGNORE:
+            return
+
+        with self._operational_lock:
+            was_overflow = self._is_overflow()
+
+            self._message_count -= 1
+            self._total_bytes -= message.ByteSize()
+
+            if self._message_count < 0 or self._total_bytes < 0:
+                warnings.warn(
+                    "Releasing a message that was never added or already released.",
+                    category=RuntimeWarning,
+                    stacklevel=2,
+                )
+                self._message_count = max(0, self._message_count)
+                self._total_bytes = max(0, self._total_bytes)
+
+            if was_overflow and not self._is_overflow():
+                _LOGGER.debug("Notifying threads waiting to add messages to flow.")
+                self._has_capacity.notify_all()
+
+    def _is_overflow(self):
+        """Determine if the current message load exceeds flow control limits.
+
+        The method assumes that the caller has obtained ``_operational_lock``.
+
+        Returns:
+            bool
+        """
+        return (
+            self._message_count > self._settings.message_limit
+            or self._total_bytes > self._settings.byte_limit
+        )

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import threading
+import time
 import warnings
 
 import pytest
@@ -24,18 +25,49 @@ from google.cloud.pubsub_v1.publisher import exceptions
 from google.cloud.pubsub_v1.publisher.flow_controller import FlowController
 
 
+def _run_in_daemon(
+    flow_controller,
+    action,
+    messages,
+    all_done_event,
+    error_event=None,
+    action_pause=None,
+):
+    """Run flow controller action (add or remove messages) in a daemon thread.
+    """
+    assert action in ("add", "release")
+
+    def run_me():
+        method = getattr(flow_controller, action)
+
+        try:
+            for msg in messages:
+                if action_pause is not None:
+                    time.sleep(action_pause)
+                method(msg)
+        except Exception:
+            if error_event is not None:
+                error_event.set()
+        else:
+            all_done_event.set()
+
+    thread = threading.Thread(target=run_me)
+    thread.daemon = True
+    thread.start()
+
+
 def test_no_overflow_no_error():
     settings = types.PublishFlowControl(
         message_limit=100,
         byte_limit=10000,
         limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
     # there should be no errors
     for data in (b"foo", b"bar", b"baz"):
         msg = types.PubsubMessage(data=data)
-        instance.add(msg)
+        flow_controller.add(msg)
 
 
 def test_overflow_no_error_on_ignore():
@@ -44,11 +76,11 @@ def test_overflow_no_error_on_ignore():
         byte_limit=2,
         limit_exceeded_behavior=types.LimitExceededBehavior.IGNORE,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
     # there should be no overflow errors
-    instance.add(types.PubsubMessage(data=b"foo"))
-    instance.add(types.PubsubMessage(data=b"bar"))
+    flow_controller.add(types.PubsubMessage(data=b"foo"))
+    flow_controller.add(types.PubsubMessage(data=b"bar"))
 
 
 def test_message_count_overflow_error():
@@ -57,11 +89,11 @@ def test_message_count_overflow_error():
         byte_limit=10000,
         limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
-    instance.add(types.PubsubMessage(data=b"foo"))
+    flow_controller.add(types.PubsubMessage(data=b"foo"))
     with pytest.raises(exceptions.FlowControlLimitError) as error:
-        instance.add(types.PubsubMessage(data=b"bar"))
+        flow_controller.add(types.PubsubMessage(data=b"bar"))
 
     assert "messages: 2 / 1" in str(error.value)
 
@@ -72,7 +104,7 @@ def test_byte_size_overflow_error():
         byte_limit=199,
         limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
     # Since the message data itself occupies 100 bytes, it means that both
     # messages combined will exceed the imposed byte limit of 199, but a single
@@ -80,9 +112,9 @@ def test_byte_size_overflow_error():
     msg1 = types.PubsubMessage(data=b"x" * 100)
     msg2 = types.PubsubMessage(data=b"y" * 100)
 
-    instance.add(msg1)
+    flow_controller.add(msg1)
     with pytest.raises(exceptions.FlowControlLimitError) as error:
-        instance.add(msg2)
+        flow_controller.add(msg2)
 
     total_size = msg1.ByteSize() + msg2.ByteSize()
     expected_info = "bytes: {} / 199".format(total_size)
@@ -95,7 +127,7 @@ def test_no_error_on_moderate_message_flow():
         byte_limit=250,
         limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
     msg1 = types.PubsubMessage(data=b"x" * 100)
     msg2 = types.PubsubMessage(data=b"y" * 100)
@@ -103,12 +135,12 @@ def test_no_error_on_moderate_message_flow():
 
     # The flow control settings will accept two in-flight messages, but not three.
     # If releasing messages works correctly, the sequence below will not raise errors.
-    instance.add(msg1)
-    instance.add(msg2)
-    instance.release(msg1)
-    instance.add(msg3)
-    instance.release(msg2)
-    instance.release(msg3)
+    flow_controller.add(msg1)
+    flow_controller.add(msg2)
+    flow_controller.release(msg1)
+    flow_controller.add(msg3)
+    flow_controller.release(msg2)
+    flow_controller.release(msg3)
 
 
 def test_rejected_messages_do_not_increase_total_load():
@@ -117,21 +149,21 @@ def test_rejected_messages_do_not_increase_total_load():
         byte_limit=150,
         limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
     msg1 = types.PubsubMessage(data=b"x" * 100)
     msg2 = types.PubsubMessage(data=b"y" * 100)
 
-    instance.add(msg1)
+    flow_controller.add(msg1)
 
     for _ in range(5):
         with pytest.raises(exceptions.FlowControlLimitError):
-            instance.add(types.PubsubMessage(data=b"z" * 100))
+            flow_controller.add(types.PubsubMessage(data=b"z" * 100))
 
     # After releasing a message we should again be able to add another one, despite
     # previously trying to add a lot of other messages.
-    instance.release(msg1)
-    instance.add(msg2)
+    flow_controller.release(msg1)
+    flow_controller.add(msg2)
 
 
 def test_incorrectly_releasing_too_many_messages():
@@ -140,7 +172,7 @@ def test_incorrectly_releasing_too_many_messages():
         byte_limit=150,
         limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
     msg1 = types.PubsubMessage(data=b"x" * 100)
     msg2 = types.PubsubMessage(data=b"y" * 100)
@@ -148,7 +180,7 @@ def test_incorrectly_releasing_too_many_messages():
 
     # Releasing a message that would make the load negative should result in a warning.
     with warnings.catch_warnings(record=True) as warned:
-        instance.release(msg1)
+        flow_controller.release(msg1)
 
     assert len(warned) == 1
     assert issubclass(warned[0].category, RuntimeWarning)
@@ -157,10 +189,10 @@ def test_incorrectly_releasing_too_many_messages():
 
     # Incorrectly removing a message does not mess up internal stats, we can
     # still only add a single message at a time to this flow.
-    instance.add(msg2)
+    flow_controller.add(msg2)
 
     with pytest.raises(exceptions.FlowControlLimitError) as error:
-        instance.add(msg3)
+        flow_controller.add(msg3)
 
     error_msg = str(error.value)
     assert "messages: 2 / 1" in error_msg
@@ -171,11 +203,11 @@ def test_incorrectly_releasing_too_many_messages():
 
 def test_blocking_on_overflow_until_free_capacity():
     settings = types.PublishFlowControl(
-        message_limit=2,
-        byte_limit=250,
+        message_limit=1,
+        byte_limit=150,
         limit_exceeded_behavior=types.LimitExceededBehavior.BLOCK,
     )
-    instance = FlowController(settings)
+    flow_controller = FlowController(settings)
 
     msg1 = types.PubsubMessage(data=b"x" * 100)
     msg2 = types.PubsubMessage(data=b"y" * 100)
@@ -184,58 +216,148 @@ def test_blocking_on_overflow_until_free_capacity():
 
     # If there is a concurrency bug in FlowController, we do not want to block
     # the main thread running the tests, thus we delegate all add/release
-    # operations to daemon threads.
-    adding_123_done = threading.Event()
+    # operations to daemon threads and check the outcome (blocked/not blocked)
+    # through Events.
+    adding_1_done = threading.Event()
+    adding_2_done = threading.Event()
+    adding_3_done = threading.Event()
     adding_4_done = threading.Event()
-    releasing_12_done = threading.Event()
+    releasing_1_done = threading.Event()
+    releasing_x_done = threading.Event()
 
-    def add_messages(messages, all_done_event):
-        try:
-            for msg in messages:
-                instance.add(msg)
-        except Exception:
-            return
-        else:
-            all_done_event.set()
+    # Adding a message with free capacity should not block.
+    _run_in_daemon(flow_controller, "add", [msg1], adding_1_done)
+    if not adding_1_done.wait(timeout=0.1):
+        pytest.fail("Adding a message with enough flow capacity blocked or errored.")
 
-    def release_messages(messages, all_done_event):
-        try:
-            for msg in messages:
-                instance.release(msg)
-        except Exception:
-            return
-        else:
-            all_done_event.set()
-
-    # The thread should block on adding the 3rd message.
-    adder_thread_123 = threading.Thread(
-        target=add_messages, args=([msg1, msg2, msg3], adding_123_done)
-    )
-    adder_thread_123.daemon = True
-    adder_thread_123.start()
-
-    all_added = adding_123_done.wait(timeout=0.1)
-    if all_added:
+    # Adding messages when there is not enough capacity should block, even if
+    # added through multiple threads.
+    _run_in_daemon(flow_controller, "add", [msg2], adding_2_done)
+    if adding_2_done.wait(timeout=0.1):
         pytest.fail("Adding a message on overflow did not block.")
 
-    # Start adding another message, but in the meantime also start freeing up
-    # enough flow capacity for it.
-    adder_thread_4 = threading.Thread(target=add_messages, args=([msg4], adding_4_done))
-    adder_thread_4.daemon = True
-    adder_thread_4.start()
+    _run_in_daemon(flow_controller, "add", [msg3], adding_3_done)
+    if adding_3_done.wait(timeout=0.1):
+        pytest.fail("Adding a message on overflow did not block.")
 
-    releaser_thread = threading.Thread(
-        target=release_messages, args=([msg1, msg2], releasing_12_done)
-    )
-    releaser_thread.daemon = True
-    releaser_thread.start()
+    _run_in_daemon(flow_controller, "add", [msg4], adding_4_done)
+    if adding_4_done.wait(timeout=0.1):
+        pytest.fail("Adding a message on overflow did not block.")
 
-    all_released = releasing_12_done.wait(timeout=0.1)
-    if not all_released:
+    # After releasing one message, there should be room for a new message, which
+    # should result in unblocking one of the waiting threads.
+    _run_in_daemon(flow_controller, "release", [msg1], releasing_1_done)
+    if not releasing_1_done.wait(timeout=0.1):
+        pytest.fail("Releasing a message blocked or errored.")
+
+    done_status = [
+        adding_2_done.wait(timeout=0.1),
+        adding_3_done.wait(timeout=0.1),
+        adding_4_done.wait(timeout=0.1),
+    ]
+
+    # In sum() we use the fact that True==1 and False==0, and that Event.wait()
+    # returns False only if it times out, i.e. its internal flag has not been set.
+    done_count = sum(done_status)
+    assert done_count == 1, "Exactly one thread should have been unblocked."
+
+    # Release another message and verify that yet another thread gets unblocked.
+    added_msg = [msg2, msg3, msg4][done_status.index(True)]
+    _run_in_daemon(flow_controller, "release", [added_msg], releasing_x_done)
+
+    if not releasing_x_done.wait(timeout=0.1):
         pytest.fail("Releasing messages blocked or errored.")
 
-    # After releasing two messages, adding a new one (msg4) should not block, even
-    # if msg3 has not been released yet.
-    all_added = adding_4_done.wait(timeout=0.1)
-    if not all_added:
-        pytest.fail("Adding a message with enough flow capacity blocked or errored.")
+    released_count = sum(
+        (
+            adding_2_done.wait(timeout=0.1),
+            adding_3_done.wait(timeout=0.1),
+            adding_4_done.wait(timeout=0.1),
+        )
+    )
+    assert released_count == 2, "Exactly two threads should have been unblocked."
+
+
+def test_error_if_mesage_would_block_indefinitely():
+    settings = types.PublishFlowControl(
+        message_limit=0,  # simulate non-sane settings
+        byte_limit=1,
+        limit_exceeded_behavior=types.LimitExceededBehavior.BLOCK,
+    )
+    flow_controller = FlowController(settings)
+
+    msg = types.PubsubMessage(data=b"xyz")
+    adding_done = threading.Event()
+    error_event = threading.Event()
+
+    _run_in_daemon(flow_controller, "add", [msg], adding_done, error_event=error_event)
+
+    assert error_event.wait(timeout=0.1), "No error on adding too large a message."
+
+    # Now that we know that an error occurs, we can check its type directly
+    # without the fear of blocking indefinitely.
+    flow_controller = FlowController(settings)  # we want a fresh controller
+    with pytest.raises(exceptions.PermanentlyBlockedError) as error_info:
+        flow_controller.add(msg)
+
+    error_msg = str(error_info.value)
+    assert "messages: 1 / 0" in error_msg
+    assert "bytes: {} / 1".format(msg.ByteSize()) in error_msg
+
+
+def test_threads_posting_large_messages_do_not_starve():
+    settings = types.PublishFlowControl(
+        message_limit=100,  # simulate non-sane settings
+        byte_limit=110,
+        limit_exceeded_behavior=types.LimitExceededBehavior.BLOCK,
+    )
+    flow_controller = FlowController(settings)
+
+    large_msg = types.PubsubMessage(data=b"x" * 100)  # close to entire byte limit
+
+    adding_initial_done = threading.Event()
+    adding_large_done = threading.Event()
+    adding_busy_done = threading.Event()
+    releasing_busy_done = threading.Event()
+    releasing_large_done = threading.Event()
+
+    # Occupy some of the flow capacity, then try to add a large message. Releasing
+    # enough messages should eventually allow the large message to come through, even
+    # if more messages are added after it (those should wait for the large message).
+    initial_messages = [types.PubsubMessage(data=b"x" * 10)] * 5
+    _run_in_daemon(flow_controller, "add", initial_messages, adding_initial_done)
+    assert adding_initial_done.wait(timeout=0.1)
+
+    _run_in_daemon(flow_controller, "add", [large_msg], adding_large_done)
+
+    # Continuously keep adding more messages after the large one.
+    messages = [types.PubsubMessage(data=b"x" * 10)] * 10
+    _run_in_daemon(flow_controller, "add", messages, adding_busy_done, action_pause=0.1)
+
+    # At the same time, gradually keep releasing the messages - the freeed up
+    # capacity should be consumed by the large message, not the other small messages
+    # being added after it.
+    _run_in_daemon(
+        flow_controller, "release", messages, releasing_busy_done, action_pause=0.1
+    )
+
+    # Sanity check - releasing should have completed by now.
+    if not releasing_busy_done.wait(timeout=1.1):
+        pytest.fail("Releasing messages blocked or errored.")
+
+    # Enough messages released, the large message should have come through in
+    # the meantime.
+    if not adding_large_done.wait(timeout=0.1):
+        pytest.fail("A thread adding a large message starved.")
+
+    if adding_busy_done.wait(timeout=0.1):
+        pytest.fail("Adding multiple small messages did not block.")
+
+    # Releasing the large message should unblock adding the remaining "busy" messages
+    # that have not been added yet.
+    _run_in_daemon(flow_controller, "release", [large_msg], releasing_large_done)
+    if not releasing_large_done.wait(timeout=0.1):
+        pytest.fail("Releasing a message blocked or errored.")
+
+    if not adding_busy_done.wait(timeout=1.0):
+        pytest.fail("Adding messages blocked or errored.")

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -1,0 +1,241 @@
+# Copyright 2020, Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import threading
+import warnings
+
+import pytest
+
+from google.cloud.pubsub_v1 import types
+from google.cloud.pubsub_v1.publisher import exceptions
+from google.cloud.pubsub_v1.publisher.flow_controller import FlowController
+
+
+def test_no_overflow_no_error():
+    settings = types.PublishFlowControl(
+        message_limit=100,
+        byte_limit=10000,
+        limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
+    )
+    instance = FlowController(settings)
+
+    # there should be no errors
+    for data in (b"foo", b"bar", b"baz"):
+        msg = types.PubsubMessage(data=data)
+        instance.add(msg)
+
+
+def test_overflow_no_error_on_ignore():
+    settings = types.PublishFlowControl(
+        message_limit=1,
+        byte_limit=2,
+        limit_exceeded_behavior=types.LimitExceededBehavior.IGNORE,
+    )
+    instance = FlowController(settings)
+
+    # there should be no overflow errors
+    instance.add(types.PubsubMessage(data=b"foo"))
+    instance.add(types.PubsubMessage(data=b"bar"))
+
+
+def test_message_count_overflow_error():
+    settings = types.PublishFlowControl(
+        message_limit=1,
+        byte_limit=10000,
+        limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
+    )
+    instance = FlowController(settings)
+
+    instance.add(types.PubsubMessage(data=b"foo"))
+    with pytest.raises(exceptions.FlowControlLimitError) as error:
+        instance.add(types.PubsubMessage(data=b"bar"))
+
+    assert "messages: 2 / 1" in str(error.value)
+
+
+def test_byte_size_overflow_error():
+    settings = types.PublishFlowControl(
+        message_limit=10000,
+        byte_limit=199,
+        limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
+    )
+    instance = FlowController(settings)
+
+    # Since the message data itself occupies 100 bytes, it means that both
+    # messages combined will exceed the imposed byte limit of 199, but a single
+    # message will not (the message size overhead is way lower than data size).
+    msg1 = types.PubsubMessage(data=b"x" * 100)
+    msg2 = types.PubsubMessage(data=b"y" * 100)
+
+    instance.add(msg1)
+    with pytest.raises(exceptions.FlowControlLimitError) as error:
+        instance.add(msg2)
+
+    total_size = msg1.ByteSize() + msg2.ByteSize()
+    expected_info = "bytes: {} / 199".format(total_size)
+    assert expected_info in str(error.value)
+
+
+def test_no_error_on_moderate_message_flow():
+    settings = types.PublishFlowControl(
+        message_limit=2,
+        byte_limit=250,
+        limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
+    )
+    instance = FlowController(settings)
+
+    msg1 = types.PubsubMessage(data=b"x" * 100)
+    msg2 = types.PubsubMessage(data=b"y" * 100)
+    msg3 = types.PubsubMessage(data=b"z" * 100)
+
+    # The flow control settings will accept two in-flight messages, but not three.
+    # If releasing messages works correctly, the sequence below will not raise errors.
+    instance.add(msg1)
+    instance.add(msg2)
+    instance.release(msg1)
+    instance.add(msg3)
+    instance.release(msg2)
+    instance.release(msg3)
+
+
+def test_rejected_messages_do_not_increase_total_load():
+    settings = types.PublishFlowControl(
+        message_limit=1,
+        byte_limit=150,
+        limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
+    )
+    instance = FlowController(settings)
+
+    msg1 = types.PubsubMessage(data=b"x" * 100)
+    msg2 = types.PubsubMessage(data=b"y" * 100)
+
+    instance.add(msg1)
+
+    for _ in range(5):
+        with pytest.raises(exceptions.FlowControlLimitError):
+            instance.add(types.PubsubMessage(data=b"z" * 100))
+
+    # After releasing a message we should again be able to add another one, despite
+    # previously trying to add a lot of other messages.
+    instance.release(msg1)
+    instance.add(msg2)
+
+
+def test_incorrectly_releasing_too_many_messages():
+    settings = types.PublishFlowControl(
+        message_limit=1,
+        byte_limit=150,
+        limit_exceeded_behavior=types.LimitExceededBehavior.ERROR,
+    )
+    instance = FlowController(settings)
+
+    msg1 = types.PubsubMessage(data=b"x" * 100)
+    msg2 = types.PubsubMessage(data=b"y" * 100)
+    msg3 = types.PubsubMessage(data=b"z" * 100)
+
+    # Releasing a message that would make the load negative should result in a warning.
+    with warnings.catch_warnings(record=True) as warned:
+        instance.release(msg1)
+
+    assert len(warned) == 1
+    assert issubclass(warned[0].category, RuntimeWarning)
+    warning_msg = str(warned[0].message)
+    assert "never added or already released" in warning_msg
+
+    # Incorrectly removing a message does not mess up internal stats, we can
+    # still only add a single message at a time to this flow.
+    instance.add(msg2)
+
+    with pytest.raises(exceptions.FlowControlLimitError) as error:
+        instance.add(msg3)
+
+    error_msg = str(error.value)
+    assert "messages: 2 / 1" in error_msg
+    total_size = msg2.ByteSize() + msg3.ByteSize()
+    expected_size_info = "bytes: {} / 150".format(total_size)
+    assert expected_size_info in error_msg
+
+
+def test_blocking_on_overflow_until_free_capacity():
+    settings = types.PublishFlowControl(
+        message_limit=2,
+        byte_limit=250,
+        limit_exceeded_behavior=types.LimitExceededBehavior.BLOCK,
+    )
+    instance = FlowController(settings)
+
+    msg1 = types.PubsubMessage(data=b"x" * 100)
+    msg2 = types.PubsubMessage(data=b"y" * 100)
+    msg3 = types.PubsubMessage(data=b"z" * 100)
+    msg4 = types.PubsubMessage(data=b"w" * 100)
+
+    # If there is a concurrency bug in FlowController, we do not want to block
+    # the main thread running the tests, thus we delegate all add/release
+    # operations to daemon threads.
+    adding_123_done = threading.Event()
+    adding_4_done = threading.Event()
+    releasing_12_done = threading.Event()
+
+    def add_messages(messages, all_done_event):
+        try:
+            for msg in messages:
+                instance.add(msg)
+        except Exception:
+            return
+        else:
+            all_done_event.set()
+
+    def release_messages(messages, all_done_event):
+        try:
+            for msg in messages:
+                instance.release(msg)
+        except Exception:
+            return
+        else:
+            all_done_event.set()
+
+    # The thread should block on adding the 3rd message.
+    adder_thread_123 = threading.Thread(
+        target=add_messages, args=([msg1, msg2, msg3], adding_123_done)
+    )
+    adder_thread_123.daemon = True
+    adder_thread_123.start()
+
+    all_added = adding_123_done.wait(timeout=0.1)
+    if all_added:
+        pytest.fail("Adding a message on overflow did not block.")
+
+    # Start adding another message, but in the meantime also start freeing up
+    # enough flow capacity for it.
+    adder_thread_4 = threading.Thread(target=add_messages, args=([msg4], adding_4_done))
+    adder_thread_4.daemon = True
+    adder_thread_4.start()
+
+    releaser_thread = threading.Thread(
+        target=release_messages, args=([msg1, msg2], releasing_12_done)
+    )
+    releaser_thread.daemon = True
+    releaser_thread.start()
+
+    all_released = releasing_12_done.wait(timeout=0.1)
+    if not all_released:
+        pytest.fail("Releasing messages blocked or errored.")
+
+    # After releasing two messages, adding a new one (msg4) should not block, even
+    # if msg3 has not been released yet.
+    all_added = adding_4_done.wait(timeout=0.1)
+    if not all_added:
+        pytest.fail("Adding a message with enough flow capacity blocked or errored.")

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -307,7 +307,7 @@ def test_error_if_mesage_would_block_indefinitely():
 
 def test_threads_posting_large_messages_do_not_starve():
     settings = types.PublishFlowControl(
-        message_limit=100,  # simulate non-sane settings
+        message_limit=100,
         byte_limit=110,
         limit_exceeded_behavior=types.LimitExceededBehavior.BLOCK,
     )

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -297,10 +297,11 @@ def test_error_if_mesage_would_block_indefinitely():
     # Now that we know that an error occurs, we can check its type directly
     # without the fear of blocking indefinitely.
     flow_controller = FlowController(settings)  # we want a fresh controller
-    with pytest.raises(exceptions.PermanentlyBlockedError) as error_info:
+    with pytest.raises(exceptions.FlowControlLimitError) as error_info:
         flow_controller.add(msg)
 
     error_msg = str(error_info.value)
+    assert "would block forever" in error_msg
     assert "messages: 1 / 0" in error_msg
     assert "bytes: {} / 1".format(msg.ByteSize()) in error_msg
 

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -125,11 +125,17 @@ def test_publish():
     creds = mock.Mock(spec=credentials.Credentials)
     client = publisher.Client(credentials=creds)
 
+    future1 = mock.sentinel.future1
+    future2 = mock.sentinel.future2
+    future1.add_done_callback = mock.Mock(spec=["__call__"])
+    future2.add_done_callback = mock.Mock(spec=["__call__"])
+
     # Use a mock in lieu of the actual batch class.
     batch = mock.Mock(spec=client._batch_class)
+
     # Set the mock up to claim indiscriminately that it accepts all messages.
     batch.will_accept.return_value = True
-    batch.publish.side_effect = (mock.sentinel.future1, mock.sentinel.future2)
+    batch.publish.side_effect = (future1, future2)
 
     topic = "topic/path"
     client._set_batch(topic, batch)
@@ -208,10 +214,13 @@ def test_publish_new_batch_needed():
     # Use mocks in lieu of the actual batch class.
     batch1 = mock.Mock(spec=client._batch_class)
     batch2 = mock.Mock(spec=client._batch_class)
+
     # Set the first mock up to claim indiscriminately that it rejects all
     # messages and the second accepts all.
+    future = mock.sentinel.future
+    future.add_done_callback = mock.Mock(spec=["__call__"])
     batch1.publish.return_value = None
-    batch2.publish.return_value = mock.sentinel.future
+    batch2.publish.return_value = future
 
     topic = "topic/path"
     client._set_batch(topic, batch1)
@@ -390,9 +399,15 @@ def test_publish_with_ordering_key():
 
     # Use a mock in lieu of the actual batch class.
     batch = mock.Mock(spec=client._batch_class)
+
     # Set the mock up to claim indiscriminately that it accepts all messages.
+    future1 = mock.sentinel.future1
+    future2 = mock.sentinel.future2
+    future1.add_done_callback = mock.Mock(spec=["__call__"])
+    future2.add_done_callback = mock.Mock(spec=["__call__"])
+
     batch.will_accept.return_value = True
-    batch.publish.side_effect = (mock.sentinel.future1, mock.sentinel.future2)
+    batch.publish.side_effect = (future1, future2)
 
     topic = "topic/path"
     ordering_key = "k1"


### PR DESCRIPTION
Closes #16.
Closes #72.

This PR adds flow control settings to publisher client, similar to what was [added](https://github.com/googleapis/java-pubsub/pull/119) to the Java client recently.

The PR does not interfere with existing publish logic (sequencers, ordering keys, batching...). Instead, it acts like a valve placed in front of the publish pipeline, and taking the configured action if it detects excessive message flow.

### Things left to do / discuss
- [ ] A system test for this? Although not sure how feasible would it be, as we would have to publish _massive_ amounts of data on fast connection to have a chance of triggering the flow control error...
- [ ] If the desired behavior is BLOCK, should blocking also support timeouts? However, every publish future gets resolved sooner or later be done (even if due to an error/timeout), and will release the corresponding message from the flow controller then.
 - [ ] Unlike Java, the `FlowControl` settings are placed under `PublisherOptions`, and not `BatchSettings`. They fit there much more naturally IMO, but I can change this.
- [ ] What should be the default `FlowControl` values (the thresholds, specifically)? I set the message count and byte size to 10x the defaults in BatchSettings, would that be fine for most users?
 - [ ] Documenting the new feature more extensively than docstring updates in this PR? Can in principle also be done in a separate PR.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
