### PR TITLE
docs: Changed Python 2 EOL notice from future to present

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -21,7 +21,7 @@
 
           <div class="body" role="main">
           	<div class="admonition" id="python2-eol"> 
-          	 On January 1, 2020 this library will no longer support Python 2 on the latest released version. 
+          	 Starting January 1, 2020, this library no longer supports Python 2 on the latest released version. 
           	 Previously released library versions will continue to be available. For more information please
           	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
           	</div>


### PR DESCRIPTION
The library has a Python 2 EOL notice in the docs.
Since the set date has passed, I've changed the phrasing from future to present.