### PR TITLE
chore: configure Python test versions in synth.py

### DIFF
--- a/google/cloud/pubsub_v1/gapic/publisher_client.py
+++ b/google/cloud/pubsub_v1/gapic/publisher_client.py
@@ -256,8 +256,10 @@ class PublisherClient(object):
         metadata=None,
     ):
         """
-        Creates the given topic with the given name. See the resource name
-        rules.
+        REQUIRED: The complete policy to be applied to the ``resource``. The
+        size of the policy is limited to a few 10s of KB. An empty policy is a
+        valid policy but certain Cloud Platform services (such as Projects)
+        might reject them.
 
         Example:
             >>> from google.cloud import pubsub_v1
@@ -269,12 +271,10 @@ class PublisherClient(object):
             >>> response = client.create_topic(name)
 
         Args:
-            name (str): Required. The name of the topic. It must have the format
-                ``"projects/{project}/topics/{topic}"``. ``{topic}`` must start with a
-                letter, and contain only letters (``[A-Za-z]``), numbers (``[0-9]``),
-                dashes (``-``), underscores (``_``), periods (``.``), tildes (``~``),
-                plus (``+``) or percent signs (``%``). It must be between 3 and 255
-                characters in length, and it must not start with ``"goog"``.
+            name (str): An annotation that describes a resource reference, see
+                ``ResourceReference``. Defines the HTTP configuration for an API
+                service. It contains a list of ``HttpRule``, each specifying the mapping
+                of an RPC method to one or more HTTP REST API methods.
             labels (dict[str -> str]): See <a href="https://cloud.google.com/pubsub/docs/labels"> Creating and
                 managing labels</a>.
             message_storage_policy (Union[dict, ~google.cloud.pubsub_v1.types.MessageStoragePolicy]): Policy constraining the set of Google Cloud Platform regions where messages
@@ -283,11 +283,7 @@ class PublisherClient(object):
 
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.pubsub_v1.types.MessageStoragePolicy`
-            kms_key_name (str): The resource name of the Cloud KMS CryptoKey to be used to protect
-                access to messages published on this topic.
-
-                The expected format is
-                ``projects/*/locations/*/keyRings/*/cryptoKeys/*``.
+            kms_key_name (str): Request message for ``GetIamPolicy`` method.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will
                 be retried using a default configuration.
@@ -373,11 +369,8 @@ class PublisherClient(object):
 
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.pubsub_v1.types.Topic`
-            update_mask (Union[dict, ~google.cloud.pubsub_v1.types.FieldMask]): Required. Indicates which fields in the provided topic to update.
-                Must be specified and non-empty. Note that if ``update_mask`` contains
-                "message_storage_policy" but the ``message_storage_policy`` is not set
-                in the ``topic`` provided above, then the updated value is determined by
-                the policy configured at the project or organization level.
+            update_mask (Union[dict, ~google.cloud.pubsub_v1.types.FieldMask]): Required. The subscription to delete. Format is
+                ``projects/{project}/subscriptions/{sub}``.
 
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.pubsub_v1.types.FieldMask`
@@ -438,8 +431,9 @@ class PublisherClient(object):
         metadata=None,
     ):
         """
-        Adds one or more messages to the topic. Returns ``NOT_FOUND`` if the
-        topic does not exist.
+        If type_name is set, this need not be set. If both this and
+        type_name are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or
+        TYPE_GROUP.
 
         Example:
             >>> from google.cloud import pubsub_v1
@@ -454,8 +448,13 @@ class PublisherClient(object):
             >>> response = client.publish(topic, messages)
 
         Args:
-            topic (str): Required. The messages in the request will be published on this
-                topic. Format is ``projects/{project}/topics/{topic}``.
+            topic (str): Acknowledges the messages associated with the ``ack_ids`` in the
+                ``AcknowledgeRequest``. The Pub/Sub system can remove the relevant
+                messages from the subscription.
+
+                Acknowledging a message whose ack deadline has expired may succeed, but
+                such a message may be redelivered later. Acknowledging a message more
+                than once will not result in an error.
             messages (list[Union[dict, ~google.cloud.pubsub_v1.types.PubsubMessage]]): Required. The messages to publish.
 
                 If a dict is provided, it must be of the same form as the protobuf
@@ -528,8 +527,8 @@ class PublisherClient(object):
             >>> response = client.get_topic(topic)
 
         Args:
-            topic (str): Required. The name of the topic to get. Format is
-                ``projects/{project}/topics/{topic}``.
+            topic (str): An annotation that describes a resource definition without a
+                corresponding message; see ``ResourceDescriptor``.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will
                 be retried using a default configuration.
@@ -611,8 +610,8 @@ class PublisherClient(object):
             ...         pass
 
         Args:
-            project (str): Required. The name of the project in which to list topics. Format is
-                ``projects/{project-id}``.
+            project (str): An annotation that describes a resource definition, see
+                ``ResourceDescriptor``.
             page_size (int): The maximum number of resources contained in the
                 underlying API response. If page streaming is performed per-
                 resource, this parameter does not affect the return value. If page
@@ -713,8 +712,9 @@ class PublisherClient(object):
             ...         pass
 
         Args:
-            topic (str): Required. The name of the topic that subscriptions are attached to.
-                Format is ``projects/{project}/topics/{topic}``.
+            topic (str): Pulls messages from the server. The server may return
+                ``UNAVAILABLE`` if there are too many concurrent pull requests pending
+                for the given subscription.
             page_size (int): The maximum number of resources contained in the
                 underlying API response. If page streaming is performed per-
                 resource, this parameter does not affect the return value. If page
@@ -822,8 +822,11 @@ class PublisherClient(object):
             ...         pass
 
         Args:
-            topic (str): Required. The name of the topic that snapshots are attached to.
-                Format is ``projects/{project}/topics/{topic}``.
+            topic (str): Required. User-provided name for this snapshot. If the name is not
+                provided in the request, the server will assign a random name for this
+                snapshot on the same project as the subscription. Note that for REST API
+                requests, you must specify a name. See the resource name rules. Format
+                is ``projects/{project}/snapshots/{snap}``.
             page_size (int): The maximum number of resources contained in the
                 underlying API response. If page streaming is performed per-
                 resource, this parameter does not affect the return value. If page
@@ -916,8 +919,13 @@ class PublisherClient(object):
             >>> client.delete_topic(topic)
 
         Args:
-            topic (str): Required. Name of the topic to delete. Format is
-                ``projects/{project}/topics/{topic}``.
+            topic (str): Establishes a stream with the server, which sends messages down to
+                the client. The client streams acknowledgements and ack deadline
+                modifications back to the server. The server will close the stream and
+                return the status on any error. The server may close the stream with
+                status ``UNAVAILABLE`` to reassign server-side resources, in which case,
+                the client should re-establish the stream. Flow control can be achieved
+                by configuring the underlying RPC channel.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will
                 be retried using a default configuration.
@@ -994,10 +1002,8 @@ class PublisherClient(object):
         Args:
             resource (str): REQUIRED: The resource for which the policy is being specified.
                 See the operation documentation for the appropriate value for this field.
-            policy (Union[dict, ~google.cloud.pubsub_v1.types.Policy]): REQUIRED: The complete policy to be applied to the ``resource``. The
-                size of the policy is limited to a few 10s of KB. An empty policy is a
-                valid policy but certain Cloud Platform services (such as Projects)
-                might reject them.
+            policy (Union[dict, ~google.cloud.pubsub_v1.types.Policy]): Role that is assigned to ``members``. For example, ``roles/viewer``,
+                ``roles/editor``, or ``roles/owner``. Required
 
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.pubsub_v1.types.Policy`
@@ -1074,8 +1080,16 @@ class PublisherClient(object):
         Args:
             resource (str): REQUIRED: The resource for which the policy is being requested.
                 See the operation documentation for the appropriate value for this field.
-            options_ (Union[dict, ~google.cloud.pubsub_v1.types.GetPolicyOptions]): OPTIONAL: A ``GetPolicyOptions`` object for specifying options to
-                ``GetIamPolicy``. This field is only used by Cloud IAM.
+            options_ (Union[dict, ~google.cloud.pubsub_v1.types.GetPolicyOptions]): The name of the topic to which dead letter messages should be
+                published. Format is ``projects/{project}/topics/{topic}``.The Cloud
+                Pub/Sub service account associated with the enclosing subscription's
+                parent project (i.e.,
+                service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must
+                have permission to Publish() to this topic.
+
+                The operation will fail if the topic does not exist. Users should ensure
+                that there is a subscription attached to this topic since messages
+                published to a topic with no subscriptions are lost.
 
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.pubsub_v1.types.GetPolicyOptions`
@@ -1162,10 +1176,7 @@ class PublisherClient(object):
         Args:
             resource (str): REQUIRED: The resource for which the policy detail is being requested.
                 See the operation documentation for the appropriate value for this field.
-            permissions (list[str]): The set of permissions to check for the ``resource``. Permissions
-                with wildcards (such as '*' or 'storage.*') are not allowed. For more
-                information see `IAM
-                Overview <https://cloud.google.com/iam/docs/overview#permissions>`__.
+            permissions (list[str]): See ``HttpRule``.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will
                 be retried using a default configuration.
@@ -1224,10 +1235,9 @@ class PublisherClient(object):
         metadata=None,
     ):
         """
-        Detaches a subscription from this topic. All messages retained in
-        the subscription are dropped. Subsequent ``Pull`` and ``StreamingPull``
-        requests will return FAILED_PRECONDITION. If the subscription is a push
-        subscription, pushes to the endpoint will stop.
+        The snapshot to seek to. The snapshot's topic must be the same as
+        that of the provided subscription. Format is
+        ``projects/{project}/snapshots/{snap}``.
 
         Example:
             >>> from google.cloud import pubsub_v1
@@ -1239,8 +1249,11 @@ class PublisherClient(object):
             >>> response = client.detach_subscription(subscription)
 
         Args:
-            subscription (str): Required. The subscription to detach. Format is
-                ``projects/{project}/subscriptions/{subscription}``.
+            subscription (str): The name of the uninterpreted option. Each string represents a
+                segment in a dot-separated name. is_extension is true iff a segment
+                represents an extension (denoted with parentheses in options specs in
+                .proto files). E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false]
+                } represents "foo.(bar.baz).qux".
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will
                 be retried using a default configuration.

--- a/google/cloud/pubsub_v1/gapic/transports/publisher_grpc_transport.py
+++ b/google/cloud/pubsub_v1/gapic/transports/publisher_grpc_transport.py
@@ -116,8 +116,10 @@ class PublisherGrpcTransport(object):
     def create_topic(self):
         """Return the gRPC stub for :meth:`PublisherClient.create_topic`.
 
-        Creates the given topic with the given name. See the resource name
-        rules.
+        REQUIRED: The complete policy to be applied to the ``resource``. The
+        size of the policy is limited to a few 10s of KB. An empty policy is a
+        valid policy but certain Cloud Platform services (such as Projects)
+        might reject them.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -144,8 +146,9 @@ class PublisherGrpcTransport(object):
     def publish(self):
         """Return the gRPC stub for :meth:`PublisherClient.publish`.
 
-        Adds one or more messages to the topic. Returns ``NOT_FOUND`` if the
-        topic does not exist.
+        If type_name is set, this need not be set. If both this and
+        type_name are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or
+        TYPE_GROUP.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -283,10 +286,9 @@ class PublisherGrpcTransport(object):
     def detach_subscription(self):
         """Return the gRPC stub for :meth:`PublisherClient.detach_subscription`.
 
-        Detaches a subscription from this topic. All messages retained in
-        the subscription are dropped. Subsequent ``Pull`` and ``StreamingPull``
-        requests will return FAILED_PRECONDITION. If the subscription is a push
-        subscription, pushes to the endpoint will stop.
+        The snapshot to seek to. The snapshot's topic must be the same as
+        that of the provided subscription. Format is
+        ``projects/{project}/snapshots/{snap}``.
 
         Returns:
             Callable: A callable which accepts the appropriate

--- a/google/cloud/pubsub_v1/gapic/transports/subscriber_grpc_transport.py
+++ b/google/cloud/pubsub_v1/gapic/transports/subscriber_grpc_transport.py
@@ -116,16 +116,7 @@ class SubscriberGrpcTransport(object):
     def create_subscription(self):
         """Return the gRPC stub for :meth:`SubscriberClient.create_subscription`.
 
-        Creates a subscription to a given topic. See the resource name
-        rules. If the subscription already exists, returns ``ALREADY_EXISTS``.
-        If the corresponding topic doesn't exist, returns ``NOT_FOUND``.
-
-        If the name is not provided in the request, the server will assign a
-        random name for this subscription on the same project as the topic,
-        conforming to the `resource name
-        format <https://cloud.google.com/pubsub/docs/admin#resource_names>`__.
-        The generated name is populated in the returned Subscription object.
-        Note that for REST API requests, you must specify a name in the request.
+        Request for the ``Pull`` method.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -178,12 +169,7 @@ class SubscriberGrpcTransport(object):
     def delete_subscription(self):
         """Return the gRPC stub for :meth:`SubscriberClient.delete_subscription`.
 
-        Deletes an existing subscription. All messages retained in the
-        subscription are immediately dropped. Calls to ``Pull`` after deletion
-        will return ``NOT_FOUND``. After a subscription is deleted, a new one
-        may be created with the same name, but the new one has no association
-        with the old subscription or its topic unless the same topic is
-        specified.
+        Response message for ``TestIamPermissions`` method.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -213,11 +199,27 @@ class SubscriberGrpcTransport(object):
     def modify_ack_deadline(self):
         """Return the gRPC stub for :meth:`SubscriberClient.modify_ack_deadline`.
 
-        Modifies the ack deadline for a specific message. This method is
-        useful to indicate that more time is needed to process a message by the
-        subscriber, or to make the message available for redelivery if the
-        processing was interrupted. Note that this does not modify the
-        subscription-level ``ackDeadlineSeconds`` used for subsequent messages.
+        If true, this is a proto3 "optional". When a proto3 field is
+        optional, it tracks presence regardless of field type.
+
+        When proto3_optional is true, this field must be belong to a oneof to
+        signal to old proto3 clients that presence is tracked for this field.
+        This oneof is known as a "synthetic" oneof, and this field must be its
+        sole member (each proto3 optional field gets its own synthetic oneof).
+        Synthetic oneofs exist in the descriptor only, and do not generate any
+        API. Synthetic oneofs must be ordered after all "real" oneofs.
+
+        For message fields, proto3_optional doesn't create any semantic change,
+        since non-repeated message fields always track presence. However it
+        still indicates the semantic detail of whether the user wrote "optional"
+        or not. This can be useful for round-tripping the .proto file. For
+        consistency we give message fields a synthetic oneof also, even though
+        it is not required to track presence. This is especially important
+        because the parser can't tell if a field is a message or an enum, so it
+        must always create a synthetic oneof.
+
+        Proto2 optional fields do not set this flag, because they already
+        indicate optional with ``LABEL_OPTIONAL``.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -230,13 +232,16 @@ class SubscriberGrpcTransport(object):
     def acknowledge(self):
         """Return the gRPC stub for :meth:`SubscriberClient.acknowledge`.
 
-        Acknowledges the messages associated with the ``ack_ids`` in the
-        ``AcknowledgeRequest``. The Pub/Sub system can remove the relevant
-        messages from the subscription.
+        The resource type. It must be in the format of
+        {service_name}/{resource_type_kind}. The ``resource_type_kind`` must be
+        singular and must not include version numbers.
 
-        Acknowledging a message whose ack deadline has expired may succeed, but
-        such a message may be redelivered later. Acknowledging a message more
-        than once will not result in an error.
+        Example: ``storage.googleapis.com/Bucket``
+
+        The value of the resource_type_kind must follow the regular expression
+        /[A-Za-z][a-zA-Z0-9]+/. It should start with an upper case character and
+        should use PascalCase (UpperCamelCase). The maximum number of characters
+        allowed for the ``resource_type_kind`` is 100.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -249,9 +254,8 @@ class SubscriberGrpcTransport(object):
     def pull(self):
         """Return the gRPC stub for :meth:`SubscriberClient.pull`.
 
-        Pulls messages from the server. The server may return
-        ``UNAVAILABLE`` if there are too many concurrent pull requests pending
-        for the given subscription.
+        Required. The subscription from which messages should be pulled.
+        Format is ``projects/{project}/subscriptions/{sub}``.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -264,13 +268,8 @@ class SubscriberGrpcTransport(object):
     def streaming_pull(self):
         """Return the gRPC stub for :meth:`SubscriberClient.streaming_pull`.
 
-        Establishes a stream with the server, which sends messages down to
-        the client. The client streams acknowledgements and ack deadline
-        modifications back to the server. The server will close the stream and
-        return the status on any error. The server may close the stream with
-        status ``UNAVAILABLE`` to reassign server-side resources, in which case,
-        the client should re-establish the stream. Flow control can be achieved
-        by configuring the underlying RPC channel.
+        A subset of ``TestPermissionsRequest.permissions`` that the caller
+        is allowed.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -283,13 +282,9 @@ class SubscriberGrpcTransport(object):
     def modify_push_config(self):
         """Return the gRPC stub for :meth:`SubscriberClient.modify_push_config`.
 
-        Modifies the ``PushConfig`` for a specified subscription.
-
-        This may be used to change a push subscription to a pull one (signified
-        by an empty ``PushConfig``) or vice versa, or change the endpoint URL
-        and other attributes of a push subscription. Messages will accumulate
-        for delivery continuously through the call regardless of changes to the
-        ``PushConfig``.
+        Denotes a field as required. This indicates that the field **must**
+        be provided as part of the request, and failure to do so will cause an
+        error (usually ``INVALID_ARGUMENT``).
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -320,21 +315,30 @@ class SubscriberGrpcTransport(object):
     def create_snapshot(self):
         """Return the gRPC stub for :meth:`SubscriberClient.create_snapshot`.
 
-        Creates a snapshot from the requested subscription. Snapshots are
-        used in Seek operations, which allow you to manage message
-        acknowledgments in bulk. That is, you can set the acknowledgment state
-        of messages in an existing subscription to the state captured by a
-        snapshot. If the snapshot already exists, returns ``ALREADY_EXISTS``. If
-        the requested subscription doesn't exist, returns ``NOT_FOUND``. If the
-        backlog in the subscription is too old -- and the resulting snapshot
-        would expire in less than 1 hour -- then ``FAILED_PRECONDITION`` is
-        returned. See also the ``Snapshot.expire_time`` field. If the name is
-        not provided in the request, the server will assign a random name for
-        this snapshot on the same project as the subscription, conforming to the
-        `resource name
-        format <https://cloud.google.com/pubsub/docs/admin#resource_names>`__.
-        The generated name is populated in the returned Snapshot object. Note
-        that for REST API requests, you must specify a name in the request.
+        Optional. The relative resource name pattern associated with this
+        resource type. The DNS prefix of the full resource name shouldn't be
+        specified here.
+
+        The path pattern must follow the syntax, which aligns with HTTP binding
+        syntax:
+
+        ::
+
+            Template = Segment { "/" Segment } ;
+            Segment = LITERAL | Variable ;
+            Variable = "{" LITERAL "}" ;
+
+        Examples:
+
+        ::
+
+            - "projects/{project}/topics/{topic}"
+            - "projects/{project}/knowledgeBases/{knowledge_base}"
+
+        The components in braces correspond to the IDs for each resource in the
+        hierarchy. It is expected that, if multiple patterns are provided, the
+        same component name (e.g. "project") refers to IDs of the same type of
+        resource.
 
         Returns:
             Callable: A callable which accepts the appropriate

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,30 +3,30 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/python-pubsub.git",
-        "sha": "06085c4083b9dccdd50383257799904510bbf3a0"
+        "remote": "git@github.com:plamut/python-pubsub.git",
+        "sha": "60fe71ae2ec2d2fcfef9e9f5c4861b3c7b2ff951"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "86285bbd54fbf9708838219e3422aa47fb8fc0b0",
-        "internalRef": "314795690"
+        "sha": "0aa979424664ab1c4808af1b5e7cc8d413b0a126",
+        "internalRef": "315793740"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "973fec811e9203b4c147121a26f1484841c465fd"
+        "sha": "e7034945fbdc0e79d3c57f6e299e5c90b0f11469"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "973fec811e9203b4c147121a26f1484841c465fd"
+        "sha": "e7034945fbdc0e79d3c57f6e299e5c90b0f11469"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -270,4 +270,23 @@ templated_files = gcp.CommonTemplates().py_library(
 )
 s.move(templated_files)
 
+# Configure Python versions in noxfile.py
+s.replace(
+    "noxfile.py",
+    'DEFAULT_PYTHON_VERSION=""',
+    'DEFAULT_PYTHON_VERSION = "3.7"',
+)
+
+s.replace(
+    "noxfile.py",
+    r"SYSTEM_TEST_PYTHON_VERSIONS=\[\]",
+    'SYSTEM_TEST_PYTHON_VERSIONS = ["2.7", "3.7"]',
+)
+
+s.replace(
+    "noxfile.py",
+    r"UNIT_TEST_PYTHON_VERSIONS=\[\]",
+    'UNIT_TEST_PYTHON_VERSIONS = ["2.7", "3.5", "3.6", "3.7", "3.8"]',
+)
+
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)


### PR DESCRIPTION
Closes #119.

This PR makes sure that Python versions in `noxfile.py` are automatically set on every code re-generation.

To test this, run `synthtool locally`. The noxfile should remain the same, i.e. configured Python versions should preserved.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
