### PR TITLE
test: fix flaky sequencer unit tests

### DIFF
--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -435,9 +435,7 @@ def test_wait_and_commit_sequencers():
 
     # Mock out time so no sleep is actually done.
     with mock.patch.object(time, "sleep"):
-        with mock.patch.object(
-            publisher.Client, "_commit_sequencers"
-        ) as _commit_sequencers:
+        with mock.patch.object(client, "_commit_sequencers") as _commit_sequencers:
             assert (
                 client.publish("topic", b"bytestring body", ordering_key="") is not None
             )
@@ -456,9 +454,7 @@ def test_stopped_client_does_not_commit_sequencers():
 
     # Mock out time so no sleep is actually done.
     with mock.patch.object(time, "sleep"):
-        with mock.patch.object(
-            publisher.Client, "_commit_sequencers"
-        ) as _commit_sequencers:
+        with mock.patch.object(client, "_commit_sequencers") as _commit_sequencers:
             assert (
                 client.publish("topic", b"bytestring body", ordering_key="") is not None
             )


### PR DESCRIPTION
Fixes #178.

Patching the client under test should be done on an instance used in a test, not on the instance's class - patching the latter can cause all other instances of the same class to share the patched method, possibly interfering with the patched method's call count.

This can probably be shipped along the new major version, as it does not interfere with the changes made there.

#### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
