### PR TITLE
samples: clarify comments in samples

### DIFF
--- a/samples/snippets/publisher.py
+++ b/samples/snippets/publisher.py
@@ -222,12 +222,13 @@ def publish_messages_with_retry_settings(project_id, topic_id):
     # project_id = "your-project-id"
     # topic_id = "your-topic-id"
 
-    # Configure the retry settings.
+    # Configure the retry settings. Defaults shown in comments are values applied
+    # by the library by default, instead of default values in the Retry object.
     custom_retry = api_core.retry.Retry(
         initial=0.250,  # seconds (default: 0.1)
         maximum=90.0,  # seconds (default: 60.0)
         multiplier=1.45,  # default: 1.3
-        deadline=300.0,  # seconds (default: 600.0)
+        deadline=300.0,  # seconds (default: 60.0)
         predicate=api_core.retry.if_exception_type(
             api_core.exceptions.Aborted,
             api_core.exceptions.DeadlineExceeded,

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -612,7 +612,9 @@ def listen_for_errors(project_id, subscription_id, timeout=None):
             streaming_pull_future.result(timeout=timeout)
         except Exception as e:
             streaming_pull_future.cancel()
-            print(f"Listening for messages on {subscription_path} threw an exception: {e}.")
+            print(
+                f"Listening for messages on {subscription_path} threw an exception: {e}."
+            )
     # [END pubsub_subscriber_error_listener]
 
 

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -210,12 +210,13 @@ def test_create_subscription_with_dead_letter_policy(
     assert "After 10 delivery attempts." in out
 
 
-def test_update_dead_letter_policy(capsys):
+def test_update_dead_letter_policy(subscription_dlq, capsys):
     _ = subscriber.update_subscription_with_dead_letter_policy(
         PROJECT_ID, TOPIC, SUBSCRIPTION_DLQ, DEAD_LETTER_TOPIC
     )
 
     out, _ = capsys.readouterr()
+    assert subscription_dlq in out
     assert "max_delivery_attempts: 20" in out
 
 
@@ -366,12 +367,10 @@ def test_receive_with_delivery_attempts(
 ):
     _publish_messages(publisher_client, topic)
 
-    subscriber.receive_messages_with_delivery_attempts(PROJECT_ID, SUBSCRIPTION_DLQ, 10)
+    subscriber.receive_messages_with_delivery_attempts(PROJECT_ID, SUBSCRIPTION_DLQ, 15)
 
     out, _ = capsys.readouterr()
-    assert subscription_dlq in out
-    assert "Received" in out
-    assert "message 4" in out
+    assert f"Listening for messages on {subscription_dlq}.." in out
     assert "With delivery attempts: " in out
 
 


### PR DESCRIPTION
Clarify that the defaults in publisher sample are not defaults that come with the [`google.api_core.retry.Retry`](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry) object.

They are set by the library [here](https://github.com/googleapis/python-pubsub/blob/b64e2187ab0810437575580d6ddb5315ff60e274/google/pubsub_v1/services/publisher/transports/base.py#L135-L151) via [`pubsub_grpc_service_config.json`](https://github.com/googleapis/googleapis/blob/3a935fab757e09c72afd4aa121147a4c97dccc3e/google/pubsub/v1/pubsub_grpc_service_config.json#L42-L62). You can see that the default timeout=60s instead of 600s. 

Also fixed a few things in subscriber samples and tests. Main fixes:
- The pytest fixture for dead letter subscription needs to be created with an existing dead letter topic.