### PR TITLE
fix: client version missing from the user agent header

### DIFF
--- a/google/pubsub_v1/services/publisher/async_client.py
+++ b/google/pubsub_v1/services/publisher/async_client.py
@@ -1138,7 +1138,9 @@ class PublisherAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/publisher/client.py
+++ b/google/pubsub_v1/services/publisher/client.py
@@ -1315,7 +1315,9 @@ class PublisherClient(metaclass=PublisherClientMeta):
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/publisher/transports/base.py
+++ b/google/pubsub_v1/services/publisher/transports/base.py
@@ -33,7 +33,9 @@ from google.pubsub_v1.types import pubsub
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/schema_service/async_client.py
+++ b/google/pubsub_v1/services/schema_service/async_client.py
@@ -849,7 +849,9 @@ class SchemaServiceAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/schema_service/client.py
+++ b/google/pubsub_v1/services/schema_service/client.py
@@ -1041,7 +1041,9 @@ class SchemaServiceClient(metaclass=SchemaServiceClientMeta):
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/schema_service/transports/base.py
+++ b/google/pubsub_v1/services/schema_service/transports/base.py
@@ -34,7 +34,9 @@ from google.pubsub_v1.types import schema as gp_schema
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/subscriber/async_client.py
+++ b/google/pubsub_v1/services/subscriber/async_client.py
@@ -1874,7 +1874,9 @@ class SubscriberAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/subscriber/client.py
+++ b/google/pubsub_v1/services/subscriber/client.py
@@ -2014,7 +2014,9 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/pubsub_v1/services/subscriber/transports/base.py
+++ b/google/pubsub_v1/services/subscriber/transports/base.py
@@ -33,7 +33,9 @@ from google.pubsub_v1.types import pubsub
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-pubsub",).version,
+        client_library_version=pkg_resources.get_distribution(
+            "google-cloud-pubsub",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,37 +3,37 @@
     {
       "git": {
         "name": ".",
-        "remote": "git@github.com:googleapis/python-pubsub",
-        "sha": "aa45340d999f845c67396e8740e96f8a8caafd16"
+        "remote": "git@github.com:plamut/python-pubsub.git",
+        "sha": "a4eab77decdd7ea0d421b56a784e8a673a5595ec"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "57fc4a8a94a5bd015a83fb0f0a1707f62254b2cd",
-        "internalRef": "348813319"
+        "sha": "61ab0348bd228c942898aee291d677f0afdb888c",
+        "internalRef": "352069361"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "6b026e1443948dcfc0b9e3289c85e940eb70f694"
+        "sha": "56ddc68f36b32341e9f22c2c59b4ce6aa3ba635f"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "6b026e1443948dcfc0b9e3289c85e940eb70f694"
+        "sha": "56ddc68f36b32341e9f22c2c59b4ce6aa3ba635f"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "6b026e1443948dcfc0b9e3289c85e940eb70f694"
+        "sha": "56ddc68f36b32341e9f22c2c59b4ce6aa3ba635f"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -97,6 +97,23 @@ s.replace(
         \g<0>""",
 )
 
+# Make sure that client library version is present in user agent header.
+s.replace(
+    [
+        "google/pubsub_v1/services/publisher/async_client.py",
+        "google/pubsub_v1/services/publisher/client.py",
+        "google/pubsub_v1/services/publisher/transports/base.py",
+        "google/pubsub_v1/services/schema_service/async_client.py",
+        "google/pubsub_v1/services/schema_service/client.py",
+        "google/pubsub_v1/services/schema_service/transports/base.py",
+        "google/pubsub_v1/services/subscriber/async_client.py",
+        "google/pubsub_v1/services/subscriber/client.py",
+        "google/pubsub_v1/services/subscriber/transports/base.py",
+    ],
+    r"""gapic_version=(pkg_resources\.get_distribution\(\s+)['"]google-pubsub['"]""",
+    "client_library_version=\g<1>'google-cloud-pubsub'",
+)
+
 # Docstrings of *_iam_policy() methods are formatted poorly and must be fixed
 # in order to avoid docstring format warnings in docs.
 s.replace("google/pubsub_v1/services/*er/client.py", r"(\s+)Args:", "\n\g<1>Args:")

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -107,7 +107,7 @@ def test_init_w_api_endpoint():
 
 
 def test_init_w_unicode_api_endpoint():
-    client_options = {"api_endpoint": u"testendpoint.google.com"}
+    client_options = {"api_endpoint": "testendpoint.google.com"}
     client = publisher.Client(client_options=client_options)
 
     assert isinstance(client.api, publisher_client.PublisherClient)
@@ -240,7 +240,7 @@ def test_publish_data_not_bytestring_error():
     client = publisher.Client(credentials=creds)
     topic = "topic/path"
     with pytest.raises(TypeError):
-        client.publish(topic, u"This is a text string.")
+        client.publish(topic, "This is a text string.")
     with pytest.raises(TypeError):
         client.publish(topic, 42)
 
@@ -321,7 +321,7 @@ def test_publish_attrs_bytestring():
 
     # The attributes should have been sent as text.
     batch.publish.assert_called_once_with(
-        gapic_types.PubsubMessage(data=b"foo", attributes={"bar": u"baz"})
+        gapic_types.PubsubMessage(data=b"foo", attributes={"bar": "baz"})
     )
 
 
@@ -360,7 +360,7 @@ def test_publish_new_batch_needed():
         commit_when_full=True,
         commit_retry=gapic_v1.method.DEFAULT,
     )
-    message_pb = gapic_types.PubsubMessage(data=b"foo", attributes={"bar": u"baz"})
+    message_pb = gapic_types.PubsubMessage(data=b"foo", attributes={"bar": "baz"})
     batch1.publish.assert_called_once_with(message_pb)
     batch2.publish.assert_called_once_with(message_pb)
 

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -26,6 +26,7 @@ import time
 
 from google.api_core import gapic_v1
 from google.api_core import retry as retries
+from google.api_core.gapic_v1.client_info import METRICS_METADATA_KEY
 from google.cloud.pubsub_v1 import publisher
 from google.cloud.pubsub_v1 import types
 
@@ -60,6 +61,26 @@ def test_init():
     assert client.batch_settings.max_bytes == 1 * 1000 * 1000
     assert client.batch_settings.max_latency == 0.01
     assert client.batch_settings.max_messages == 100
+
+
+def test_init_default_client_info():
+    creds = mock.Mock(spec=credentials.Credentials)
+    client = publisher.Client(credentials=creds)
+
+    installed_version = publisher.client.__version__
+    expected_client_info = f"gccl/{installed_version}"
+
+    for wrapped_method in client.api.transport._wrapped_methods.values():
+        user_agent = next(
+            (
+                header_value
+                for header, header_value in wrapped_method._metadata
+                if header == METRICS_METADATA_KEY
+            ),
+            None,
+        )
+        assert user_agent is not None
+        assert expected_client_info in user_agent
 
 
 def test_init_w_custom_transport():

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -68,7 +68,7 @@ def test_init_w_api_endpoint():
 
 
 def test_init_w_unicode_api_endpoint():
-    client_options = {"api_endpoint": u"testendpoint.google.com"}
+    client_options = {"api_endpoint": "testendpoint.google.com"}
     client = subscriber.Client(client_options=client_options)
 
     assert isinstance(client.api, subscriber_client.SubscriberClient)

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -16,6 +16,7 @@ from google.auth import credentials
 import grpc
 import mock
 
+from google.api_core.gapic_v1.client_info import METRICS_METADATA_KEY
 from google.cloud.pubsub_v1 import subscriber
 from google.cloud.pubsub_v1 import types
 from google.cloud.pubsub_v1.subscriber import futures
@@ -27,6 +28,26 @@ def test_init():
     creds = mock.Mock(spec=credentials.Credentials)
     client = subscriber.Client(credentials=creds)
     assert isinstance(client.api, subscriber_client.SubscriberClient)
+
+
+def test_init_default_client_info():
+    creds = mock.Mock(spec=credentials.Credentials)
+    client = subscriber.Client(credentials=creds)
+
+    installed_version = subscriber.client.__version__
+    expected_client_info = f"gccl/{installed_version}"
+
+    for wrapped_method in client.api.transport._wrapped_methods.values():
+        user_agent = next(
+            (
+                header_value
+                for header, header_value in wrapped_method._metadata
+                if header == METRICS_METADATA_KEY
+            ),
+            None,
+        )
+        assert user_agent is not None
+        assert expected_client_info in user_agent
 
 
 def test_init_w_custom_transport():


### PR DESCRIPTION
Fixes #200.

This PR patches the generated code so that client library version is actually included in the `x-goog-api-client` metrics key.

PR checlist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
