### PR TITLE
revert: remove graceful streaming pull shutdown

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -99,6 +99,9 @@ class Dispatcher(object):
             ValueError: If ``action`` isn't one of the expected actions
                 "ack", "drop", "lease", "modify_ack_deadline" or "nack".
         """
+        if not self._manager.is_active:
+            return
+
         batched_commands = collections.defaultdict(list)
 
         for item in items:

--- a/google/cloud/pubsub_v1/subscriber/_protocol/heartbeater.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/heartbeater.py
@@ -35,11 +35,10 @@ class Heartbeater(object):
         self._period = period
 
     def heartbeat(self):
-        """Periodically send streaming pull heartbeats.
-        """
-        while not self._stop_event.is_set():
-            if self._manager.heartbeat():
-                _LOGGER.debug("Sent heartbeat.")
+        """Periodically send heartbeats."""
+        while self._manager.is_active and not self._stop_event.is_set():
+            self._manager.heartbeat()
+            _LOGGER.debug("Sent heartbeat.")
             self._stop_event.wait(timeout=self._period)
 
         _LOGGER.info("%s exiting.", _HEARTBEAT_WORKER_NAME)

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -126,7 +126,7 @@ class Leaser(object):
         ack IDs, then waits for most of that time (but with jitter), and
         repeats.
         """
-        while not self._stop_event.is_set():
+        while self._manager.is_active and not self._stop_event.is_set():
             # Determine the appropriate duration for the lease. This is
             # based off of how long previous messages have taken to ack, with
             # a sensible default and within the ranges allowed by Pub/Sub.

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -43,23 +43,12 @@ class StreamingPullFuture(futures.Future):
         else:
             self.set_exception(result)
 
-    def cancel(self, await_msg_callbacks=False):
+    def cancel(self):
         """Stops pulling messages and shutdowns the background thread consuming
         messages.
-
-        Args:
-            await_msg_callbacks (bool):
-                If ``True``, the method will block until the background stream and its
-                helper threads have has been terminated, as well as all currently
-                executing message callbacks are done processing.
-
-                If ``False`` (default), the method returns immediately after the
-                background stream and its helper threads have has been terminated, but
-                some of the message callback threads might still be running at that
-                point.
         """
         self._cancelled = True
-        return self._manager.close(await_msg_callbacks=await_msg_callbacks)
+        return self._manager.close()
 
     def cancelled(self):
         """

--- a/tests/system.py
+++ b/tests/system.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import concurrent.futures
 import datetime
 import itertools
 import operator as op
@@ -610,78 +609,6 @@ class TestStreamingPull(object):
         finally:
             subscription_future.cancel()  # trigger clean shutdown
 
-    def test_streaming_pull_blocking_shutdown(
-        self, publisher, topic_path, subscriber, subscription_path, cleanup
-    ):
-        # Make sure the topic and subscription get deleted.
-        cleanup.append((publisher.delete_topic, (), {"topic": topic_path}))
-        cleanup.append(
-            (subscriber.delete_subscription, (), {"subscription": subscription_path})
-        )
-
-        # The ACK-s are only persisted if *all* messages published in the same batch
-        # are ACK-ed. We thus publish each message in its own batch so that the backend
-        # treats all messages' ACKs independently of each other.
-        publisher.create_topic(name=topic_path)
-        subscriber.create_subscription(name=subscription_path, topic=topic_path)
-        _publish_messages(publisher, topic_path, batch_sizes=[1] * 10)
-
-        # Artificially delay message processing, gracefully shutdown the streaming pull
-        # in the meantime, then verify that those messages were nevertheless processed.
-        processed_messages = []
-
-        def callback(message):
-            time.sleep(15)
-            processed_messages.append(message.data)
-            message.ack()
-
-        # Flow control limits should exceed the number of worker threads, so that some
-        # of the messages will be blocked on waiting for free scheduler threads.
-        flow_control = pubsub_v1.types.FlowControl(max_messages=5)
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
-        scheduler = pubsub_v1.subscriber.scheduler.ThreadScheduler(executor=executor)
-        subscription_future = subscriber.subscribe(
-            subscription_path,
-            callback=callback,
-            flow_control=flow_control,
-            scheduler=scheduler,
-        )
-
-        try:
-            subscription_future.result(timeout=10)  # less than the sleep in callback
-        except exceptions.TimeoutError:
-            subscription_future.cancel(await_msg_callbacks=True)
-
-        # The shutdown should have waited for the already executing callbacks to finish.
-        assert len(processed_messages) == 3
-
-        # The messages that were not processed should have been NACK-ed and we should
-        # receive them again quite soon.
-        all_done = threading.Barrier(7 + 1, timeout=5)  # +1 because of the main thread
-        remaining = []
-
-        def callback2(message):
-            remaining.append(message.data)
-            message.ack()
-            all_done.wait()
-
-        subscription_future = subscriber.subscribe(
-            subscription_path, callback=callback2
-        )
-
-        try:
-            all_done.wait()
-        except threading.BrokenBarrierError:  # PRAGMA: no cover
-            pytest.fail("The remaining messages have not been re-delivered in time.")
-        finally:
-            subscription_future.cancel(await_msg_callbacks=False)
-
-        # There should be 7 messages left that were not yet processed and none of them
-        # should be a message that should have already been sucessfully processed in the
-        # first streaming pull.
-        assert len(remaining) == 7
-        assert not (set(processed_messages) & set(remaining))  # no re-delivery
-
 
 @pytest.mark.skipif(
     "KOKORO_GFILE_DIR" not in os.environ,
@@ -863,8 +790,8 @@ def _publish_messages(publisher, topic_path, batch_sizes):
     publish_futures = []
     msg_counter = itertools.count(start=1)
 
-    for batch_num, batch_size in enumerate(batch_sizes, start=1):
-        msg_batch = _make_messages(count=batch_size, batch_num=batch_num)
+    for batch_size in batch_sizes:
+        msg_batch = _make_messages(count=batch_size)
         for msg in msg_batch:
             future = publisher.publish(topic_path, msg, seq_num=str(next(msg_counter)))
             publish_futures.append(future)
@@ -875,10 +802,9 @@ def _publish_messages(publisher, topic_path, batch_sizes):
         future.result(timeout=30)
 
 
-def _make_messages(count, batch_num):
+def _make_messages(count):
     messages = [
-        f"message {i}/{count} of batch {batch_num}".encode("utf-8")
-        for i in range(1, count + 1)
+        "message {}/{}".format(i, count).encode("utf-8") for i in range(1, count + 1)
     ]
     return messages
 

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -29,14 +29,14 @@ import pytest
 @pytest.mark.parametrize(
     "item,method_name",
     [
-        (requests.AckRequest("0", 0, 0, ""), "ack"),
-        (requests.DropRequest("0", 0, ""), "drop"),
-        (requests.LeaseRequest("0", 0, ""), "lease"),
-        (requests.ModAckRequest("0", 0), "modify_ack_deadline"),
-        (requests.NackRequest("0", 0, ""), "nack"),
+        (requests.AckRequest(0, 0, 0, ""), "ack"),
+        (requests.DropRequest(0, 0, ""), "drop"),
+        (requests.LeaseRequest(0, 0, ""), "lease"),
+        (requests.ModAckRequest(0, 0), "modify_ack_deadline"),
+        (requests.NackRequest(0, 0, ""), "nack"),
     ],
 )
-def test_dispatch_callback_active_manager(item, method_name):
+def test_dispatch_callback(item, method_name):
     manager = mock.create_autospec(
         streaming_pull_manager.StreamingPullManager, instance=True
     )
@@ -50,29 +50,16 @@ def test_dispatch_callback_active_manager(item, method_name):
     method.assert_called_once_with([item])
 
 
-@pytest.mark.parametrize(
-    "item,method_name",
-    [
-        (requests.AckRequest("0", 0, 0, ""), "ack"),
-        (requests.DropRequest("0", 0, ""), "drop"),
-        (requests.LeaseRequest("0", 0, ""), "lease"),
-        (requests.ModAckRequest("0", 0), "modify_ack_deadline"),
-        (requests.NackRequest("0", 0, ""), "nack"),
-    ],
-)
-def test_dispatch_callback_inactive_manager(item, method_name):
+def test_dispatch_callback_inactive():
     manager = mock.create_autospec(
         streaming_pull_manager.StreamingPullManager, instance=True
     )
     manager.is_active = False
     dispatcher_ = dispatcher.Dispatcher(manager, mock.sentinel.queue)
 
-    items = [item]
+    dispatcher_.dispatch_callback([requests.AckRequest(0, 0, 0, "")])
 
-    with mock.patch.object(dispatcher_, method_name) as method:
-        dispatcher_.dispatch_callback(items)
-
-    method.assert_called_once_with([item])
+    manager.send.assert_not_called()
 
 
 def test_ack():

--- a/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -69,18 +69,10 @@ class TestStreamingPullFuture(object):
         result = future.result()
         assert result == "foo"  # on close callback was a no-op
 
-    def test_cancel_default_nonblocking_manager_shutdown(self):
+    def test_cancel(self):
         future = self.make_future()
 
         future.cancel()
 
-        future._manager.close.assert_called_once_with(await_msg_callbacks=False)
-        assert future.cancelled()
-
-    def test_cancel_blocking_manager_shutdown(self):
-        future = self.make_future()
-
-        future.cancel(await_msg_callbacks=True)
-
-        future._manager.close.assert_called_once_with(await_msg_callbacks=True)
+        future._manager.close.assert_called_once()
         assert future.cancelled()

--- a/tests/unit/pubsub_v1/subscriber/test_leaser.py
+++ b/tests/unit/pubsub_v1/subscriber/test_leaser.py
@@ -88,21 +88,15 @@ def create_manager(flow_control=types.FlowControl()):
     return manager
 
 
-def test_maintain_leases_inactive_manager(caplog):
+def test_maintain_leases_inactive(caplog):
     caplog.set_level(logging.INFO)
     manager = create_manager()
     manager.is_active = False
 
     leaser_ = leaser.Leaser(manager)
-    make_sleep_mark_event_as_done(leaser_)
-    leaser_.add(
-        [requests.LeaseRequest(ack_id="my_ack_ID", byte_size=42, ordering_key="")]
-    )
 
     leaser_.maintain_leases()
 
-    # Leases should still be maintained even if the manager is inactive.
-    manager.dispatcher.modify_ack_deadline.assert_called()
     assert "exiting" in caplog.text
 
 
@@ -118,20 +112,20 @@ def test_maintain_leases_stopped(caplog):
     assert "exiting" in caplog.text
 
 
-def make_sleep_mark_event_as_done(leaser):
-    # Make sleep actually trigger the done event so that heartbeat()
+def make_sleep_mark_manager_as_inactive(leaser):
+    # Make sleep mark the manager as inactive so that maintain_leases
     # exits at the end of the first run.
-    def trigger_done(timeout):
+    def trigger_inactive(timeout):
         assert 0 < timeout < 10
-        leaser._stop_event.set()
+        leaser._manager.is_active = False
 
-    leaser._stop_event.wait = trigger_done
+    leaser._stop_event.wait = trigger_inactive
 
 
 def test_maintain_leases_ack_ids():
     manager = create_manager()
     leaser_ = leaser.Leaser(manager)
-    make_sleep_mark_event_as_done(leaser_)
+    make_sleep_mark_manager_as_inactive(leaser_)
     leaser_.add(
         [requests.LeaseRequest(ack_id="my ack id", byte_size=50, ordering_key="")]
     )
@@ -146,7 +140,7 @@ def test_maintain_leases_ack_ids():
 def test_maintain_leases_no_ack_ids():
     manager = create_manager()
     leaser_ = leaser.Leaser(manager)
-    make_sleep_mark_event_as_done(leaser_)
+    make_sleep_mark_manager_as_inactive(leaser_)
 
     leaser_.maintain_leases()
 
@@ -157,7 +151,7 @@ def test_maintain_leases_no_ack_ids():
 def test_maintain_leases_outdated_items(time):
     manager = create_manager()
     leaser_ = leaser.Leaser(manager)
-    make_sleep_mark_event_as_done(leaser_)
+    make_sleep_mark_manager_as_inactive(leaser_)
 
     # Add and start expiry timer at the beginning of the timeline.
     time.return_value = 0

--- a/tests/unit/pubsub_v1/subscriber/test_scheduler.py
+++ b/tests/unit/pubsub_v1/subscriber/test_scheduler.py
@@ -14,7 +14,6 @@
 
 import concurrent.futures
 import threading
-import time
 
 import mock
 from six.moves import queue
@@ -39,89 +38,19 @@ def test_constructor_options():
     assert scheduler_._executor == mock.sentinel.executor
 
 
-def test_schedule_executes_submitted_items():
+def test_schedule():
     called_with = []
-    callback_done_twice = threading.Barrier(3)  # 3 == 2x callback + 1x main thread
+    called = threading.Event()
 
     def callback(*args, **kwargs):
-        called_with.append((args, kwargs))  # appends are thread-safe
-        callback_done_twice.wait()
+        called_with.append((args, kwargs))
+        called.set()
 
     scheduler_ = scheduler.ThreadScheduler()
 
     scheduler_.schedule(callback, "arg1", kwarg1="meep")
-    scheduler_.schedule(callback, "arg2", kwarg2="boop")
 
-    callback_done_twice.wait(timeout=3.0)
-    result = scheduler_.shutdown()
+    called.wait()
+    scheduler_.shutdown()
 
-    assert result == []  # no scheduled items dropped
-
-    expected_calls = [(("arg1",), {"kwarg1": "meep"}), (("arg2",), {"kwarg2": "boop"})]
-    assert sorted(called_with) == expected_calls
-
-
-def test_shutdown_nonblocking_by_default():
-    called_with = []
-    at_least_one_called = threading.Event()
-    at_least_one_completed = threading.Event()
-
-    def callback(message):
-        called_with.append(message)  # appends are thread-safe
-        at_least_one_called.set()
-        time.sleep(1.0)
-        at_least_one_completed.set()
-
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    scheduler_ = scheduler.ThreadScheduler(executor=executor)
-
-    scheduler_.schedule(callback, "message_1")
-    scheduler_.schedule(callback, "message_2")
-
-    at_least_one_called.wait()
-    dropped = scheduler_.shutdown()
-
-    assert len(called_with) == 1
-    assert called_with[0] in {"message_1", "message_2"}
-
-    assert len(dropped) == 1
-    assert dropped[0] in {"message_1", "message_2"}
-    assert dropped[0] != called_with[0]  # the dropped message was not the processed one
-
-    err_msg = (
-        "Shutdown should not have waited "
-        "for the already running callbacks to complete."
-    )
-    assert not at_least_one_completed.is_set(), err_msg
-
-
-def test_shutdown_blocking_awaits_running_callbacks():
-    called_with = []
-    at_least_one_called = threading.Event()
-    at_least_one_completed = threading.Event()
-
-    def callback(message):
-        called_with.append(message)  # appends are thread-safe
-        at_least_one_called.set()
-        time.sleep(1.0)
-        at_least_one_completed.set()
-
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    scheduler_ = scheduler.ThreadScheduler(executor=executor)
-
-    scheduler_.schedule(callback, "message_1")
-    scheduler_.schedule(callback, "message_2")
-
-    at_least_one_called.wait()
-    dropped = scheduler_.shutdown(await_msg_callbacks=True)
-
-    assert len(called_with) == 1
-    assert called_with[0] in {"message_1", "message_2"}
-
-    # The work items that have not been started yet should still be dropped.
-    assert len(dropped) == 1
-    assert dropped[0] in {"message_1", "message_2"}
-    assert dropped[0] != called_with[0]  # the dropped message was not the processed one
-
-    err_msg = "Shutdown did not wait for the already running callbacks to complete."
-    assert at_least_one_completed.is_set(), err_msg
+    assert called_with == [(("arg1",), {"kwarg1": "meep"})]


### PR DESCRIPTION
Reverts googleapis/python-pubsub#292

Release 2.4.0 which contains this feature has been yanked from PyPi: https://pypi.org/project/google-cloud-pubsub/

Graceful streaming pull shutdown introduces an optional wait on callbacks on streaming pull futures. It would otherwise break the streaming pull future returned by the Pub/Sub Lite subscriber client. See https://github.com/googleapis/python-pubsublite/issues/95