### PR TITLE
samples: downgrade lib version in requirements.txt for samples testing

### DIFF
--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-pubsub==2.4.0
+google-cloud-pubsub==2.3.0
 avro==1.10.1


### PR DESCRIPTION
Release 2.4.0 has been yanked from PyPi: https://pypi.org/project/google-cloud-pubsub/