### PR TITLE
chore: emit a warning if return_immediately flag is set with synchronous pull

### DIFF
--- a/google/pubsub_v1/services/subscriber/async_client.py
+++ b/google/pubsub_v1/services/subscriber/async_client.py
@@ -28,6 +28,7 @@ from typing import (
     Type,
     Union,
 )
+import warnings
 import pkg_resources
 
 import google.api_core.client_options as ClientOptions  # type: ignore
@@ -934,6 +935,12 @@ class SubscriberAsyncClient:
             request.return_immediately = return_immediately
         if max_messages is not None:
             request.max_messages = max_messages
+
+        if request.return_immediately:
+            warnings.warn(
+                "The return_immediately flag is deprecated and should be set to False.",
+                category=DeprecationWarning,
+            )
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.

--- a/google/pubsub_v1/services/subscriber/client.py
+++ b/google/pubsub_v1/services/subscriber/client.py
@@ -31,6 +31,7 @@ from typing import (
     Type,
     Union,
 )
+import warnings
 import pkg_resources
 
 from google.api_core import client_options as client_options_lib  # type: ignore
@@ -1123,6 +1124,12 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
                 request.return_immediately = return_immediately
             if max_messages is not None:
                 request.max_messages = max_messages
+
+        if request.return_immediately:
+            warnings.warn(
+                "The return_immediately flag is deprecated and should be set to False.",
+                category=DeprecationWarning,
+            )
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.


### PR DESCRIPTION
Closes #350.

This PR patches the generated client to emit a DeprecationWarning if `return_immediately` flag is set.

**PR checklist**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
