### PR TITLE
chore: bump test coverage to 100%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 fail_under = 100
 show_missing = True
 omit =
+    google/cloud/__init__.py
     google/pubsub/__init__.py
 exclude_lines =
     # Re-enable the standard pragma

--- a/google/cloud/pubsub_v1/publisher/_batch/base.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/base.py
@@ -50,7 +50,7 @@ class Batch(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def make_lock():
+    def make_lock():  # pragma: NO COVER
         """Return a lock in the chosen concurrency model.
 
         Returns:
@@ -60,7 +60,7 @@ class Batch(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def messages(self):
+    def messages(self):  # pragma: NO COVER
         """Return the messages currently in the batch.
 
         Returns:
@@ -70,7 +70,7 @@ class Batch(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def size(self):
+    def size(self):  # pragma: NO COVER
         """Return the total size of all of the messages currently in the batch.
 
         The size includes any overhead of the actual ``PublishRequest`` that is
@@ -84,7 +84,7 @@ class Batch(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def settings(self):
+    def settings(self):  # pragma: NO COVER
         """Return the batch settings.
 
         Returns:
@@ -95,7 +95,7 @@ class Batch(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def status(self):
+    def status(self):  # pragma: NO COVER
         """Return the status of this batch.
 
         Returns:
@@ -106,7 +106,7 @@ class Batch(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def cancel(self, cancellation_reason):
+    def cancel(self, cancellation_reason):  # pragma: NO COVER
         """Complete pending futures with an exception.
 
         This method must be called before publishing starts (ie: while the
@@ -119,7 +119,7 @@ class Batch(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def publish(self, message):
+    def publish(self, message):  # pragma: NO COVER
         """Publish a single message.
 
         Add the given message to this object; this will cause it to be

--- a/google/cloud/pubsub_v1/publisher/_sequencer/base.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/base.py
@@ -24,7 +24,7 @@ class Sequencer(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def is_finished(self):
+    def is_finished(self):  # pragma: NO COVER
         """ Whether the sequencer is finished and should be cleaned up.
 
             Returns:
@@ -34,7 +34,7 @@ class Sequencer(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def unpause(self, message):
+    def unpause(self, message):  # pragma: NO COVER
         """ Unpauses this sequencer.
 
         Raises:
@@ -45,7 +45,7 @@ class Sequencer(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def publish(self, message, retry=None):
+    def publish(self, message, retry=None):  # pragma: NO COVER
         """ Publish message for this ordering key.
 
         Args:

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -49,14 +49,6 @@ _BLACKLISTED_METHODS = (
 _raw_proto_pubbsub_message = gapic_types.PubsubMessage.pb()
 
 
-def _set_nested_value(container, value, keys):
-    current = container
-    for key in keys[:-1]:
-        current = current.setdefault(key, {})
-    current[keys[-1]] = value
-    return container
-
-
 @_gapic.add_methods(publisher_client.PublisherClient, blacklist=_BLACKLISTED_METHODS)
 class Client(object):
     """A publisher client for Google Cloud Pub/Sub.

--- a/google/cloud/pubsub_v1/publisher/flow_controller.py
+++ b/google/cloud/pubsub_v1/publisher/flow_controller.py
@@ -285,7 +285,9 @@ class FlowController(object):
         if total_bytes is None:
             total_bytes = self._total_bytes
 
-        if reserved_bytes is None:
+        # The following check is here for completness even though it always passes (no
+        # calling code currently needs to override reserved_bytes).
+        if reserved_bytes is None:  # pragma: no branch
             reserved_bytes = self._reserved_bytes
 
         return msg.format(

--- a/google/cloud/pubsub_v1/publisher/flow_controller.py
+++ b/google/cloud/pubsub_v1/publisher/flow_controller.py
@@ -258,7 +258,7 @@ class FlowController(object):
 
         return size_overflow or msg_count_overflow
 
-    def _load_info(self, message_count=None, total_bytes=None, reserved_bytes=None):
+    def _load_info(self, message_count=None, total_bytes=None):
         """Return the current flow control load information.
 
         The caller can optionally adjust some of the values to fit its reporting
@@ -271,8 +271,6 @@ class FlowController(object):
                 The value to override the current message count with.
             total_bytes (Optional[int]):
                 The value to override the current total bytes with.
-            reserved_bytes (Optional[int]):
-                The value to override the current number of reserved bytes with.
 
         Returns:
             str
@@ -285,15 +283,10 @@ class FlowController(object):
         if total_bytes is None:
             total_bytes = self._total_bytes
 
-        # The following check is here for completness even though it always passes (no
-        # calling code currently needs to override reserved_bytes).
-        if reserved_bytes is None:  # pragma: no branch
-            reserved_bytes = self._reserved_bytes
-
         return msg.format(
             message_count,
             self._settings.message_limit,
             total_bytes,
             self._settings.byte_limit,
-            reserved_bytes,
+            self._reserved_bytes,
         )

--- a/google/cloud/pubsub_v1/subscriber/scheduler.py
+++ b/google/cloud/pubsub_v1/subscriber/scheduler.py
@@ -31,7 +31,7 @@ class Scheduler(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def queue(self):
+    def queue(self):  # pragma: NO COVER
         """Queue: A concurrency-safe queue specific to the underlying
         concurrency implementation.
 
@@ -40,7 +40,7 @@ class Scheduler(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def schedule(self, callback, *args, **kwargs):
+    def schedule(self, callback, *args, **kwargs):  # pragma: NO COVER
         """Schedule the callback to be called asynchronously.
 
         Args:
@@ -54,7 +54,7 @@ class Scheduler(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def shutdown(self, await_msg_callbacks=False):
+    def shutdown(self, await_msg_callbacks=False):  # pragma: NO COVER
         """Shuts down the scheduler and immediately end all pending callbacks.
 
         Args:

--- a/synth.py
+++ b/synth.py
@@ -262,7 +262,7 @@ s.replace(
 templated_files = gcp.CommonTemplates().py_library(
     microgenerator=True,
     samples=True,
-    cov_level=99,
+    cov_level=100,
     system_test_external_dependencies=["psutil"],
 )
 s.move(templated_files, excludes=[".coveragerc"])

--- a/synth.py
+++ b/synth.py
@@ -206,6 +206,14 @@ s.replace(
     "\n\g<0>",
 )
 
+# The namespace package declaration in google/cloud/__init__.py should be excluded
+# from coverage.
+s.replace(
+    ".coveragerc",
+    r"((?P<indent>[^\n\S]+)google/pubsub/__init__\.py)",
+    "\g<indent>google/cloud/__init__.py\n\g<0>",
+)
+
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------

--- a/tests/unit/gapic/pubsub_v1/test_subscriber.py
+++ b/tests/unit/gapic/pubsub_v1/test_subscriber.py
@@ -17,6 +17,7 @@
 
 import os
 import mock
+import warnings
 
 import grpc
 from grpc.experimental import aio
@@ -2338,11 +2339,13 @@ def test_pull_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.pull(
-            subscription="subscription_value",
-            return_immediately=True,
-            max_messages=1277,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            client.pull(
+                subscription="subscription_value",
+                return_immediately=True,
+                max_messages=1277,
+            )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2382,11 +2385,13 @@ async def test_pull_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(pubsub.PullResponse())
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.pull(
-            subscription="subscription_value",
-            return_immediately=True,
-            max_messages=1277,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            await client.pull(
+                subscription="subscription_value",
+                return_immediately=True,
+                max_messages=1277,
+            )
 
         # Establish that the underlying call was made with the expected
         # request object values.

--- a/tests/unit/pubsub_v1/publisher/batch/test_base.py
+++ b/tests/unit/pubsub_v1/publisher/batch/test_base.py
@@ -24,12 +24,11 @@ from google.cloud.pubsub_v1.publisher._batch.thread import Batch
 from google.pubsub_v1 import types as gapic_types
 
 
-def create_batch(status=None, settings=types.BatchSettings()):
+def create_batch(status, settings=types.BatchSettings()):
     """Create a batch object, which does not commit.
 
     Args:
-        status (str): If provided, the batch's internal status will be set
-            to the provided status.
+        status (str): The batch's internal status will be set to the provided status.
 
     Returns:
         ~.pubsub_v1.publisher.batch.thread.Batch: The batch object
@@ -37,8 +36,7 @@ def create_batch(status=None, settings=types.BatchSettings()):
     creds = mock.Mock(spec=credentials.Credentials)
     client = publisher.Client(credentials=creds)
     batch = Batch(client, "topic_name", settings)
-    if status:
-        batch._status = status
+    batch._status = status
     return batch
 
 

--- a/tests/unit/pubsub_v1/publisher/batch/test_thread.py
+++ b/tests/unit/pubsub_v1/publisher/batch/test_thread.py
@@ -188,7 +188,7 @@ def test_client_api_publish_not_blocking_additional_publish_calls():
 
         start = datetime.datetime.now()
         event_set = api_publish_called.wait(timeout=1.0)
-        if not event_set:
+        if not event_set:  # pragma: NO COVER
             pytest.fail("API publish was not called in time")
         batch.publish({"data": b"second message"})
         end = datetime.datetime.now()

--- a/tests/unit/pubsub_v1/publisher/sequencer/test_unordered_sequencer.py
+++ b/tests/unit/pubsub_v1/publisher/sequencer/test_unordered_sequencer.py
@@ -17,6 +17,7 @@ import pytest
 
 from google.auth import credentials
 from google.cloud.pubsub_v1 import publisher
+from google.cloud.pubsub_v1 import types
 from google.cloud.pubsub_v1.publisher._batch import base
 from google.cloud.pubsub_v1.publisher._sequencer import unordered_sequencer
 from google.pubsub_v1 import types as gapic_types
@@ -119,13 +120,19 @@ def test_publish_batch_full():
 def test_publish_after_batch_error():
     client = create_client()
     message = create_message()
-    batch = mock.Mock(spec=client._batch_class)
+
+    batch = client._batch_class(
+        client, "topic_name", types.BatchSettings(max_latency=float("inf"))
+    )
+    batch._messages.append(mock.Mock(name="message"))  # Make batch truthy (non-empty).
 
     sequencer = unordered_sequencer.UnorderedSequencer(client, "topic_name")
     sequencer._set_batch(batch)
 
-    sequencer.commit()
-    batch.commit.assert_called_once()
+    with mock.patch.object(batch, "commit") as fake_batch_commit:
+        sequencer.commit()
+
+    fake_batch_commit.assert_called_once()
 
     # Simulate publish RPC failing.
     batch._set_status(base.BatchStatus.ERROR)

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -47,7 +47,7 @@ def _run_in_daemon(
                     time.sleep(action_pause)
                 method(msg)
         except Exception:
-            if error_event is not None:
+            if error_event is not None:  # pragma: NO COVER
                 error_event.set()
         else:
             all_done_event.set()
@@ -229,27 +229,29 @@ def test_blocking_on_overflow_until_free_capacity():
     # Adding a message with free capacity should not block.
     _run_in_daemon(flow_controller, "add", [msg1], adding_1_done)
     if not adding_1_done.wait(timeout=0.1):
-        pytest.fail("Adding a message with enough flow capacity blocked or errored.")
+        pytest.fail(  # pragma: NO COVER
+            "Adding a message with enough flow capacity blocked or errored."
+        )
 
     # Adding messages when there is not enough capacity should block, even if
     # added through multiple threads.
     _run_in_daemon(flow_controller, "add", [msg2], adding_2_done)
     if adding_2_done.wait(timeout=0.1):
-        pytest.fail("Adding a message on overflow did not block.")
+        pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
     _run_in_daemon(flow_controller, "add", [msg3], adding_3_done)
     if adding_3_done.wait(timeout=0.1):
-        pytest.fail("Adding a message on overflow did not block.")
+        pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
     _run_in_daemon(flow_controller, "add", [msg4], adding_4_done)
     if adding_4_done.wait(timeout=0.1):
-        pytest.fail("Adding a message on overflow did not block.")
+        pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
     # After releasing one message, there should be room for a new message, which
     # should result in unblocking one of the waiting threads.
     _run_in_daemon(flow_controller, "release", [msg1], releasing_1_done)
     if not releasing_1_done.wait(timeout=0.1):
-        pytest.fail("Releasing a message blocked or errored.")
+        pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER
 
     done_status = [
         adding_2_done.wait(timeout=0.1),
@@ -267,7 +269,7 @@ def test_blocking_on_overflow_until_free_capacity():
     _run_in_daemon(flow_controller, "release", [added_msg], releasing_x_done)
 
     if not releasing_x_done.wait(timeout=0.1):
-        pytest.fail("Releasing messages blocked or errored.")
+        pytest.fail("Releasing messages blocked or errored.")  # pragma: NO COVER
 
     released_count = sum(
         (
@@ -345,24 +347,24 @@ def test_threads_posting_large_messages_do_not_starve():
 
     # Sanity check - releasing should have completed by now.
     if not releasing_busy_done.wait(timeout=1.1):
-        pytest.fail("Releasing messages blocked or errored.")
+        pytest.fail("Releasing messages blocked or errored.")  # pragma: NO COVER
 
     # Enough messages released, the large message should have come through in
     # the meantime.
     if not adding_large_done.wait(timeout=0.1):
-        pytest.fail("A thread adding a large message starved.")
+        pytest.fail("A thread adding a large message starved.")  # pragma: NO COVER
 
     if adding_busy_done.wait(timeout=0.1):
-        pytest.fail("Adding multiple small messages did not block.")
+        pytest.fail("Adding multiple small messages did not block.")  # pragma: NO COVER
 
     # Releasing the large message should unblock adding the remaining "busy" messages
     # that have not been added yet.
     _run_in_daemon(flow_controller, "release", [large_msg], releasing_large_done)
     if not releasing_large_done.wait(timeout=0.1):
-        pytest.fail("Releasing a message blocked or errored.")
+        pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER
 
     if not adding_busy_done.wait(timeout=1.0):
-        pytest.fail("Adding messages blocked or errored.")
+        pytest.fail("Adding messages blocked or errored.")  # pragma: NO COVER
 
 
 def test_warning_on_internal_reservation_stats_error_when_unblocking():
@@ -387,13 +389,15 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
     # Adding a message with free capacity should not block.
     _run_in_daemon(flow_controller, "add", [msg1], adding_1_done)
     if not adding_1_done.wait(timeout=0.1):
-        pytest.fail("Adding a message with enough flow capacity blocked or errored.")
+        pytest.fail(  # pragma: NO COVER
+            "Adding a message with enough flow capacity blocked or errored."
+        )
 
     # Adding messages when there is not enough capacity should block, even if
     # added through multiple threads.
     _run_in_daemon(flow_controller, "add", [msg2], adding_2_done)
     if adding_2_done.wait(timeout=0.1):
-        pytest.fail("Adding a message on overflow did not block.")
+        pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
     # Intentionally corrupt internal stats
     reservation = next(iter(flow_controller._byte_reservations.values()), None)
@@ -403,7 +407,7 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
     with warnings.catch_warnings(record=True) as warned:
         _run_in_daemon(flow_controller, "release", [msg1], releasing_1_done)
         if not releasing_1_done.wait(timeout=0.1):
-            pytest.fail("Releasing a message blocked or errored.")
+            pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER
 
     matches = [warning for warning in warned if warning.category is RuntimeWarning]
     assert len(matches) == 1

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -77,7 +77,7 @@ def test_init_default_client_info():
                 for header, header_value in wrapped_method._metadata
                 if header == METRICS_METADATA_KEY
             ),
-            None,
+            None,  # pragma: NO COVER
         )
         assert user_agent is not None
         assert expected_client_info in user_agent

--- a/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -116,9 +116,6 @@ def check_call_types(mock, *args, **kwargs):
         assert len(call_args) == len(args)
         for n, argtype in enumerate(args):
             assert isinstance(call_args[n], argtype)
-        for argname, argtype in kwargs:
-            assert argname in call_kwargs
-            assert isinstance(call_kwargs[argname], argtype)
 
 
 def test_ack():

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -47,7 +47,7 @@ def test_init_default_client_info():
                 for header, header_value in wrapped_method._metadata
                 if header == METRICS_METADATA_KEY
             ),
-            None,
+            None,  # pragma: NO COVER
         )
         assert user_agent is not None
         assert expected_client_info in user_agent

--- a/tests/unit/pubsub_v1/test__gapic.py
+++ b/tests/unit/pubsub_v1/test__gapic.py
@@ -32,7 +32,7 @@ class SourceClass(object):
         return "source class class method"
 
     @classmethod
-    def blacklisted_method(cls):
+    def blacklisted_method(cls):  # pragma: NO COVER
         return "source class blacklisted method"
 
 
@@ -42,7 +42,7 @@ def test_add_method():
         def __init__(self):
             self.api = SourceClass()
 
-        def method(self):
+        def method(self):  # pragma: NO COVER
             return "foo class instance method"
 
     foo = Foo()


### PR DESCRIPTION
Closes #363.
Closes #367.

This PR fixes the code lines/paths that currently drag the overall coverage down.

The majority are error code paths in tests that are never executed if a test passes, and abstract methods that we do not explicitly test if they indeed raise `NotImplementedError`. The rest is some unused code and a few other misc. cleanups.

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
