### PR TITLE
feat: make publish futures compatible with `concurrent.futures.as_completed()`

### DIFF
--- a/google/cloud/pubsub_v1/publisher/futures.py
+++ b/google/cloud/pubsub_v1/publisher/futures.py
@@ -43,10 +43,4 @@ class Future(futures.Future):
             Exception: For undefined exceptions in the underlying
                 call execution.
         """
-        # Attempt to get the exception if there is one.
-        # If there is not one, then we know everything worked, and we can
-        # return an appropriate value.
-        err = self.exception(timeout=timeout)
-        if err is None:
-            return self._result
-        raise err
+        return super().result(timeout=timeout)


### PR DESCRIPTION
Closes #368.

After studying the [as_completed()](https://github.com/python/cpython/blob/15ad30d88fead718b7eeff8c54454b82753d520e/Lib/concurrent/futures/_base.py#L201-L261) code from the standard library, it actually seemed easier to modify our futures implementation, as opposed to writing our own `as_completed()` logic, which would still require changes to the Future, too (think: locking and notifying).

The drawback of course is relying on implementation details from `concurrent.futures`, but good tests should help us here. Let's discuss this drawback here.

**Current approach pros:**
- Fewer code changes, no need to write our own `as_completed()` logic.
- The library's API surface does not change, no incompatibility with other official Pub/Sub clients, no dilemma and coordination on whether to move the implementation to `api-core`.

**Current approach cons:**
- Compatibility depends on `concurrent.futures` implementation details, although tests should help here. In addition, the standard lib's implementation seems very stable, and changes infrequent ([blame](https://github.com/python/cpython/blame/57873af35aad98c6428b1718aaee4b16a82ea3f5/Lib/concurrent/futures/_base.py)) - the key implementation details are more than 10 **years** old.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


