### PR TITLE
fix: do not crash if distribution cannot be found when extracting semver

### DIFF
--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -39,6 +39,8 @@ from google.pubsub_v1.services.publisher import client as publisher_client
 try:
     __version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
 except pkg_resources.DistributionNotFound:
+    # Distribution might not be available if we are not running from within a
+    # PIP package.
     __version__ = "0.0"
 
 _LOGGER = logging.getLogger(__name__)

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -36,7 +36,10 @@ from google.cloud.pubsub_v1.publisher.flow_controller import FlowController
 from google.pubsub_v1 import types as gapic_types
 from google.pubsub_v1.services.publisher import client as publisher_client
 
-__version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
+try:
+    __version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
+except pkg_resources.DistributionNotFound:
+    __version__ = "0.0"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -30,6 +30,8 @@ from google.pubsub_v1.services.subscriber import client as subscriber_client
 try:
     __version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
 except pkg_resources.DistributionNotFound:
+    # Distribution might not be available if we are not running from within
+    # a PIP package.
     __version__ = "0.0"
 
 _BLACKLISTED_METHODS = (

--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -27,7 +27,10 @@ from google.cloud.pubsub_v1.subscriber._protocol import streaming_pull_manager
 from google.pubsub_v1.services.subscriber import client as subscriber_client
 
 
-__version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
+try:
+    __version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
+except pkg_resources.DistributionNotFound:
+    __version__ = "0.0"
 
 _BLACKLISTED_METHODS = (
     "publish",


### PR DESCRIPTION
In the case where a user is not running from within a pip package, the google-cloud-pubsub distribution might not be available. At the moment this will cause a fatal DistributionNotFound error because in the publisher and subscriber client, we try to extract the distribution version using 'pkg_resources.get_distribution("google-cloud-pubsub").version'.

In the case where a distribution is not found, making the change to set the version to 0.0.