### PR TITLE
feat: make publish futures compatible with concurrent.futures.as_completed()

### DIFF
--- a/google/cloud/pubsub_v1/futures.py
+++ b/google/cloud/pubsub_v1/futures.py
@@ -55,3 +55,19 @@ class Future(concurrent.futures.Future, google.api_core.future.Future):
         raise NotImplementedError(
             "Only used by executors from `concurrent.futures` package."
         )
+
+    def set_result(self, result):
+        """Set the return value of work associated with the future.
+
+        Do not use this method, it should only be used internally by the library and its
+        unit tests.
+        """
+        return super().set_result(result=result)
+
+    def set_exception(self, exception):
+        """Set the result of the future as being the given exception.
+
+        Do not use this method, it should only be used internally by the library and its
+        unit tests.
+        """
+        return super().set_exception(exception=exception)

--- a/google/cloud/pubsub_v1/futures.py
+++ b/google/cloud/pubsub_v1/futures.py
@@ -14,14 +14,13 @@
 
 from __future__ import absolute_import
 
-import threading
-import uuid
+import concurrent.futures
+import warnings
 
 import google.api_core.future
-from google.cloud.pubsub_v1.publisher import exceptions
 
 
-class Future(google.api_core.future.Future):
+class Future(concurrent.futures.Future, google.api_core.future.Future):
     """Encapsulation of the asynchronous execution of an action.
 
     This object is returned from asychronous Pub/Sub calls, and is the
@@ -31,156 +30,28 @@ class Future(google.api_core.future.Future):
     methods in this library.
 
     Args:
-        completed (Optional[Any]): An event, with the same interface as
-            :class:`threading.Event`. This is provided so that callers
-            with different concurrency models (e.g. ``threading`` or
-            ``multiprocessing``) can supply an event that is compatible
-            with that model. The ``wait()`` and ``set()`` methods will be
-            used. If this argument is not provided, then a new
-            :class:`threading.Event` will be created and used.
+        completed (Optional[Any]):
+             [deprecated] Not used anymore and will be removed in the future.
     """
 
-    # This could be a sentinel object or None, but the sentinel object's ID
-    # can change if the process is forked, and None has the possibility of
-    # actually being a result.
-    _SENTINEL = uuid.uuid4()
-
     def __init__(self, completed=None):
-        self._result = self._SENTINEL
-        self._exception = self._SENTINEL
-        self._callbacks = []
-        if completed is None:
-            completed = threading.Event()
-        self._completed = completed
+        if completed is not None:
+            msg = (
+                "Parameter `completed` is not used anymore and will be "
+                "removed in the future."
+            )
+            warnings.warn(msg, category=DeprecationWarning)
 
-    def cancel(self):
-        """Actions in Pub/Sub generally may not be canceled.
-
-        This method always returns False.
-        """
-        return False
-
-    def cancelled(self):
-        """Actions in Pub/Sub generally may not be canceled.
-
-        This method always returns False.
-        """
-        return False
+        super().__init__()
 
     def running(self):
-        """Actions in Pub/Sub generally may not be canceled.
+        """Return ``True`` if the associated Pub/Sub action has not yet completed.
 
-        Returns:
-            bool: ``True`` if this method has not yet completed, or
-                ``False`` if it has completed.
+        Returns: bool:
         """
         return not self.done()
 
-    def done(self):
-        """Return True the future is done, False otherwise.
-
-        This still returns True in failure cases; checking :meth:`result` or
-        :meth:`exception` is the canonical way to assess success or failure.
-        """
-        return self._exception != self._SENTINEL or self._result != self._SENTINEL
-
-    def result(self, timeout=None):
-        """Resolve the future and return a value where appropriate.
-
-        Args:
-            timeout (Union[int, float]): The number of seconds before this call
-                times out and raises TimeoutError.
-
-        Raises:
-            concurrent.futures.TimeoutError: If the request times out.
-            Exception: For undefined exceptions in the underlying
-                call execution.
-        """
-        # Attempt to get the exception if there is one.
-        # If there is not one, then we know everything worked, and we can
-        # return an appropriate value.
-        err = self.exception(timeout=timeout)
-        if err is None:
-            return self._result
-        raise err
-
-    def exception(self, timeout=None):
-        """Return the exception raised by the call, if any.
-
-        Args:
-            timeout (Union[int, float]): The number of seconds before this call
-                times out and raises TimeoutError.
-
-        Raises:
-            concurrent.futures.TimeoutError: If the request times out.
-
-        Returns:
-            Exception: The exception raised by the call, if any.
-        """
-        # Wait until the future is done.
-        if not self._completed.wait(timeout=timeout):
-            raise exceptions.TimeoutError("Timed out waiting for result.")
-
-        # If the batch completed successfully, this should return None.
-        if self._result != self._SENTINEL:
-            return None
-
-        # Okay, this batch had an error; this should return it.
-        return self._exception
-
-    def add_done_callback(self, callback):
-        """Attach the provided callable to the future.
-
-        The provided function is called, with this future as its only argument,
-        when the future finishes running.
-
-        Args:
-            callback (Callable): The function to call.
-
-        Returns:
-            None
-        """
-        if self.done():
-            return callback(self)
-        self._callbacks.append(callback)
-
-    def set_result(self, result):
-        """Set the result of the future to the provided result.
-
-        Args:
-            result (Any): The result
-        """
-        # Sanity check: A future can only complete once.
-        if self.done():
-            raise RuntimeError("set_result can only be called once.")
-
-        # Set the result and trigger the future.
-        self._result = result
-        self._trigger()
-
-    def set_exception(self, exception):
-        """Set the result of the future to the given exception.
-
-        Args:
-            exception (:exc:`Exception`): The exception raised.
-        """
-        # Sanity check: A future can only complete once.
-        if self.done():
-            raise RuntimeError("set_exception can only be called once.")
-
-        # Set the exception and trigger the future.
-        self._exception = exception
-        self._trigger()
-
-    def _trigger(self):
-        """Trigger all callbacks registered to this Future.
-
-        This method is called internally by the batch once the batch
-        completes.
-
-        Args:
-            message_id (str): The message ID, as a string.
-        """
-        self._completed.set()
-        for callback in self._callbacks:
-            callback(self)
+    def set_running_or_notify_cancel(self):
+        raise NotImplementedError(
+            "Only used by executors from `concurrent.futures` package."
+        )

--- a/google/cloud/pubsub_v1/futures.py
+++ b/google/cloud/pubsub_v1/futures.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 import concurrent.futures
-import warnings
 
 import google.api_core.future
 
@@ -28,21 +27,7 @@ class Future(concurrent.futures.Future, google.api_core.future.Future):
 
     This object should not be created directly, but is returned by other
     methods in this library.
-
-    Args:
-        completed (Optional[Any]):
-             [deprecated] Not used anymore and will be removed in the future.
     """
-
-    def __init__(self, completed=None):
-        if completed is not None:
-            msg = (
-                "Parameter `completed` is not used anymore and will be "
-                "removed in the future."
-            )
-            warnings.warn(msg, category=DeprecationWarning)
-
-        super().__init__()
 
     def running(self):
         """Return ``True`` if the associated Pub/Sub action has not yet completed.

--- a/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -378,7 +378,7 @@ class Batch(base.Batch):
 
                 # Track the future on this batch (so that the result of the
                 # future can be set).
-                future = futures.Future(completed=threading.Event())
+                future = futures.Future()
                 self._futures.append(future)
 
         # Try to commit, but it must be **without** the lock held, since

--- a/google/cloud/pubsub_v1/publisher/futures.py
+++ b/google/cloud/pubsub_v1/publisher/futures.py
@@ -25,6 +25,20 @@ class Future(futures.Future):
     ID, unless an error occurs.
     """
 
+    def cancel(self):
+        """Actions in Pub/Sub generally may not be canceled.
+
+        This method always returns ``False``.
+        """
+        return False
+
+    def cancelled(self):
+        """Actions in Pub/Sub generally may not be canceled.
+
+        This method always returns ``False``.
+        """
+        return False
+
     def result(self, timeout=None):
         """Return the message ID or raise an exception.
 
@@ -43,10 +57,4 @@ class Future(futures.Future):
             Exception: For undefined exceptions in the underlying
                 call execution.
         """
-        # Attempt to get the exception if there is one.
-        # If there is not one, then we know everything worked, and we can
-        # return an appropriate value.
-        err = self.exception(timeout=timeout)
-        if err is None:
-            return self._result
-        raise err
+        return super().result(timeout=timeout)

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -30,7 +30,7 @@ class StreamingPullFuture(futures.Future):
         super(StreamingPullFuture, self).__init__()
         self._manager = manager
         self._manager.add_close_callback(self._on_close_callback)
-        self._cancelled = False
+        self.__cancelled = False
 
     def _on_close_callback(self, manager, result):
         if self.done():
@@ -49,7 +49,7 @@ class StreamingPullFuture(futures.Future):
         """
         # NOTE: We circumvent the base future's self._state to track the cancellation
         # state, as this state has different meaning with streaming pull futures.
-        self._cancelled = True
+        self.__cancelled = True
         return self._manager.close()
 
     def cancelled(self):
@@ -57,4 +57,4 @@ class StreamingPullFuture(futures.Future):
         returns:
             bool: ``True`` if the subscription has been cancelled.
         """
-        return self._cancelled
+        return self.__cancelled

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -47,6 +47,8 @@ class StreamingPullFuture(futures.Future):
         """Stops pulling messages and shutdowns the background thread consuming
         messages.
         """
+        # NOTE: We circumvent the base future's self._state to track the cancellation
+        # state, as this state has different meaning with streaming pull futures.
         self._cancelled = True
         return self._manager.close()
 

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -28,8 +28,8 @@ class StreamingPullFuture(futures.Future):
 
     def __init__(self, manager):
         super(StreamingPullFuture, self).__init__()
-        self._manager = manager
-        self._manager.add_close_callback(self._on_close_callback)
+        self.__manager = manager
+        self.__manager.add_close_callback(self._on_close_callback)
         self.__cancelled = False
 
     def _on_close_callback(self, manager, result):
@@ -50,7 +50,7 @@ class StreamingPullFuture(futures.Future):
         # NOTE: We circumvent the base future's self._state to track the cancellation
         # state, as this state has different meaning with streaming pull futures.
         self.__cancelled = True
-        return self._manager.close()
+        return self.__manager.close()
 
     def cancelled(self):
         """

--- a/tests/unit/pubsub_v1/publisher/test_futures_publisher.py
+++ b/tests/unit/pubsub_v1/publisher/test_futures_publisher.py
@@ -20,6 +20,14 @@ from google.cloud.pubsub_v1.publisher import futures
 
 
 class TestFuture(object):
+    def test_cancel(self):
+        future = futures.Future()
+        assert future.cancel() is False
+
+    def test_cancelled(self):
+        future = futures.Future()
+        assert future.cancelled() is False
+
     def test_result_on_success(self):
         future = futures.Future()
         future.set_result("570307942214048")

--- a/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -31,13 +31,12 @@ class TestStreamingPullFuture(object):
 
     def test_default_state(self):
         future = self.make_future()
+        manager = future._StreamingPullFuture__manager
 
         assert future.running()
         assert not future.done()
         assert not future.cancelled()
-        future._manager.add_close_callback.assert_called_once_with(
-            future._on_close_callback
-        )
+        manager.add_close_callback.assert_called_once_with(future._on_close_callback)
 
     def test__on_close_callback_success(self):
         future = self.make_future()
@@ -71,8 +70,9 @@ class TestStreamingPullFuture(object):
 
     def test_cancel(self):
         future = self.make_future()
+        manager = future._StreamingPullFuture__manager
 
         future.cancel()
 
-        future._manager.close.assert_called_once()
+        manager.close.assert_called_once()
         assert future.cancelled()

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -137,7 +137,8 @@ def test_subscribe(manager_open, creds):
     future = client.subscribe("sub_name_a", callback=mock.sentinel.callback)
     assert isinstance(future, futures.StreamingPullFuture)
 
-    assert future._manager._subscription == "sub_name_a"
+    manager = future._StreamingPullFuture__manager
+    assert manager._subscription == "sub_name_a"
     manager_open.assert_called_once_with(
         mock.ANY,
         callback=mock.sentinel.callback,
@@ -164,10 +165,11 @@ def test_subscribe_options(manager_open, creds):
     )
     assert isinstance(future, futures.StreamingPullFuture)
 
-    assert future._manager._subscription == "sub_name_a"
-    assert future._manager.flow_control == flow_control
-    assert future._manager._scheduler == scheduler
-    assert future._manager._await_callbacks_on_shutdown is mock.sentinel.await_callbacks
+    manager = future._StreamingPullFuture__manager
+    assert manager._subscription == "sub_name_a"
+    assert manager.flow_control == flow_control
+    assert manager._scheduler == scheduler
+    assert manager._await_callbacks_on_shutdown is mock.sentinel.await_callbacks
     manager_open.assert_called_once_with(
         mock.ANY,
         callback=mock.sentinel.callback,

--- a/tests/unit/pubsub_v1/test_futures.py
+++ b/tests/unit/pubsub_v1/test_futures.py
@@ -19,7 +19,6 @@ import time
 
 import mock
 import pytest
-import warnings
 
 from google.cloud.pubsub_v1 import exceptions
 from google.cloud.pubsub_v1 import futures
@@ -27,25 +26,6 @@ from google.cloud.pubsub_v1 import futures
 
 def _future(*args, **kwargs):
     return futures.Future(*args, **kwargs)
-
-
-def test_constructor_default_no_warning():
-    with warnings.catch_warnings(record=True) as warned:
-        _future()
-    assert not warned
-
-
-def test_constructor_custom_completed_arg():
-    completed = mock.sentinel.completed
-
-    with warnings.catch_warnings(record=True) as warned:
-        _future(completed=completed)
-
-    assert len(warned) == 1
-    assert issubclass(warned[0].category, DeprecationWarning)
-    warning_msg = str(warned[0].message)
-    assert "completed" in warning_msg
-    assert "not used" in warning_msg
 
 
 def test_running():

--- a/tests/unit/pubsub_v1/test_futures.py
+++ b/tests/unit/pubsub_v1/test_futures.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import concurrent.futures
+import sys
 import threading
 import time
 
@@ -126,6 +127,10 @@ def test_trigger():
     callback.assert_called_once_with(future)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="InvalidStateError is only available in Python 3.8+",
+)
 def test_set_result_once_only():
     future = _future()
     future.set_result("12345")
@@ -133,6 +138,10 @@ def test_set_result_once_only():
         future.set_result("67890")
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="InvalidStateError is only available in Python 3.8+",
+)
 def test_set_exception_once_only():
     future = _future()
     future.set_exception(ValueError("wah wah"))

--- a/tests/unit/pubsub_v1/test_futures.py
+++ b/tests/unit/pubsub_v1/test_futures.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import threading
+import time
 
 import mock
 import pytest
+import warnings
 
 from google.cloud.pubsub_v1 import exceptions
 from google.cloud.pubsub_v1 import futures
@@ -25,34 +28,23 @@ def _future(*args, **kwargs):
     return futures.Future(*args, **kwargs)
 
 
-def test_constructor_defaults():
-    with mock.patch.object(threading, "Event", autospec=True) as Event:
-        future = _future()
-
-    assert future._result == futures.Future._SENTINEL
-    assert future._exception == futures.Future._SENTINEL
-    assert future._callbacks == []
-    assert future._completed is Event.return_value
-
-    Event.assert_called_once_with()
+def test_constructor_default_no_warning():
+    with warnings.catch_warnings(record=True) as warned:
+        _future()
+    assert not warned
 
 
-def test_constructor_explicit_completed():
+def test_constructor_custom_completed_arg():
     completed = mock.sentinel.completed
-    future = _future(completed=completed)
 
-    assert future._result == futures.Future._SENTINEL
-    assert future._exception == futures.Future._SENTINEL
-    assert future._callbacks == []
-    assert future._completed is completed
+    with warnings.catch_warnings(record=True) as warned:
+        _future(completed=completed)
 
-
-def test_cancel():
-    assert _future().cancel() is False
-
-
-def test_cancelled():
-    assert _future().cancelled() is False
+    assert len(warned) == 1
+    assert issubclass(warned[0].category, DeprecationWarning)
+    warning_msg = str(warned[0].message)
+    assert "completed" in warning_msg
+    assert "not used" in warning_msg
 
 
 def test_running():
@@ -112,8 +104,8 @@ def test_add_done_callback_pending_batch():
     future = _future()
     callback = mock.Mock()
     future.add_done_callback(callback)
-    assert len(future._callbacks) == 1
-    assert callback in future._callbacks
+    assert len(future._done_callbacks) == 1
+    assert callback in future._done_callbacks
     assert callback.call_count == 0
 
 
@@ -137,12 +129,54 @@ def test_trigger():
 def test_set_result_once_only():
     future = _future()
     future.set_result("12345")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(concurrent.futures.InvalidStateError):
         future.set_result("67890")
 
 
 def test_set_exception_once_only():
     future = _future()
     future.set_exception(ValueError("wah wah"))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(concurrent.futures.InvalidStateError):
         future.set_exception(TypeError("other wah wah"))
+
+
+def test_as_completed_compatibility():
+    all_futures = {i: _future() for i in range(6)}
+    done_futures = []
+
+    def resolve_future(future_idx, delay=0):
+        time.sleep(delay)
+        future = all_futures[future_idx]
+        if future_idx % 2 == 0:
+            future.set_result(f"{future_idx}: I'm done!")
+        else:
+            future.set_exception(Exception(f"Future {future_idx} errored"))
+
+    all_futures[2].set_result("2: I'm done!")
+
+    # Start marking the futures as completed (either with success or error) at
+    # different times and check that ther "as completed" order is correct.
+    for future_idx, delay in ((0, 0.8), (3, 0.6), (1, 0.4), (5, 0.2)):
+        threading.Thread(
+            target=resolve_future, args=(future_idx, delay), daemon=True
+        ).start()
+
+    try:
+        # Use a loop instead of a list comprehension to gather futures completed
+        # before the timeout error occurs.
+        for future in concurrent.futures.as_completed(all_futures.values(), timeout=1):
+            done_futures.append(future)
+    except concurrent.futures.TimeoutError:
+        pass
+    else:  # pragma: NO COVER
+        pytest.fail("Not all Futures should have been recognized as completed.")
+
+    # NOTE: Future 4 was never resolved.
+    expected = [
+        all_futures[2],
+        all_futures[5],
+        all_futures[1],
+        all_futures[3],
+        all_futures[0],
+    ]
+    assert done_futures == expected

--- a/tests/unit/pubsub_v1/test_futures.py
+++ b/tests/unit/pubsub_v1/test_futures.py
@@ -127,6 +127,17 @@ def test_trigger():
     callback.assert_called_once_with(future)
 
 
+def test_set_running_or_notify_cancel_not_implemented_error():
+    future = _future()
+    with pytest.raises(NotImplementedError) as exc_info:
+        future.set_running_or_notify_cancel()
+
+    assert exc_info.value.args
+    error_msg = exc_info.value.args[0]
+    assert "used by executors" in error_msg
+    assert "concurrent.futures" in error_msg
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 8),
     reason="InvalidStateError is only available in Python 3.8+",


### PR DESCRIPTION
Closes #368.
Possibly supersedes #374.

This is a different approach to the same feature request which does not rely on implementation details of `concurrent.futures.Future` (as discussed offline). Instead, the custom base `Future` implementation is _replaced_ with the one from `concurrent.futures` package with only minor adjustments to fit specific needs of publisher/subscriber futures.

The interface stays the same, and the `isinstance()` checks should keep working, as `concurrent.futures.Future` is injected is injected into the right place in MRO.

**PR checklist**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
