### PR TITLE
fix: memory leak when publishing messages

### DIFF
--- a/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -207,9 +207,10 @@ class Batch(base.Batch):
 
     def _start_commit_thread(self):
         """Start a new thread to actually handle the commit."""
-
+        # NOTE: If the thread is *not* a daemon, a memory leak exists for some reason...
+        # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829910303
         commit_thread = threading.Thread(
-            name="Thread-CommitBatchPublisher", target=self._commit
+            name="Thread-CommitBatchPublisher", target=self._commit, daemon=True
         )
         commit_thread.start()
 

--- a/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -207,8 +207,9 @@ class Batch(base.Batch):
 
     def _start_commit_thread(self):
         """Start a new thread to actually handle the commit."""
-        # NOTE: If the thread is *not* a daemon, a memory leak exists for some reason...
+        # NOTE: If the thread is *not* a daemon, a memory leak exists sue to a CPython issue.
         # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829910303
+        # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-830092418
         commit_thread = threading.Thread(
             name="Thread-CommitBatchPublisher", target=self._commit, daemon=True
         )

--- a/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -207,7 +207,7 @@ class Batch(base.Batch):
 
     def _start_commit_thread(self):
         """Start a new thread to actually handle the commit."""
-        # NOTE: If the thread is *not* a daemon, a memory leak exists sue to a CPython issue.
+        # NOTE: If the thread is *not* a daemon, a memory leak exists due to a CPython issue.
         # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829910303
         # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-830092418
         commit_thread = threading.Thread(

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -375,8 +375,12 @@ class Client(object):
 
     def _start_commit_thread(self):
         """Start a new thread to actually wait and commit the sequencers."""
+        # NOTE: If the thread is *not* a daemon, a memory leak exists for some reason...
+        # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829910303
         self._commit_thread = threading.Thread(
-            name="Thread-PubSubBatchCommitter", target=self._wait_and_commit_sequencers
+            name="Thread-PubSubBatchCommitter",
+            target=self._wait_and_commit_sequencers,
+            daemon=True,
         )
         self._commit_thread.start()
 

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -375,8 +375,9 @@ class Client(object):
 
     def _start_commit_thread(self):
         """Start a new thread to actually wait and commit the sequencers."""
-        # NOTE: If the thread is *not* a daemon, a memory leak exists for some reason...
+        # NOTE: If the thread is *not* a daemon, a memory leak exists sue to a CPython issue.
         # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829910303
+        # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-830092418
         self._commit_thread = threading.Thread(
             name="Thread-PubSubBatchCommitter",
             target=self._wait_and_commit_sequencers,

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -375,7 +375,7 @@ class Client(object):
 
     def _start_commit_thread(self):
         """Start a new thread to actually wait and commit the sequencers."""
-        # NOTE: If the thread is *not* a daemon, a memory leak exists sue to a CPython issue.
+        # NOTE: If the thread is *not* a daemon, a memory leak exists due to a CPython issue.
         # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829910303
         # https://github.com/googleapis/python-pubsub/issues/395#issuecomment-830092418
         self._commit_thread = threading.Thread(


### PR DESCRIPTION
Fixes #395.

If publish threads are marked as daemonic, the leak seemingly disappears.

### How to verify

Set up a topic and a subscription, install `memoryprofiler`. Add the `@profile` decorator to the `main()` function from the [sample code](https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829263348) and run it (with and without the fix):
```
$ mprof run sample.py
```

After each run, plot the memory usage graph:
```
$ mprof plot
```

The graphs should look similar to the ones posted [here](https://github.com/googleapis/python-pubsub/issues/395#issuecomment-829910303).



### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
