### PR TITLE
fix: ACK deadline set for received messages can be too low 

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/_protocol/histogram.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/histogram.py
@@ -15,6 +15,10 @@
 from __future__ import absolute_import, division
 
 
+MIN_ACK_DEADLINE = 10
+MAX_ACK_DEADLINE = 600
+
+
 class Histogram(object):
     """Representation of a single histogram.
 
@@ -83,41 +87,43 @@ class Histogram(object):
     def max(self):
         """Return the maximum value in this histogram.
 
-        If there are no values in the histogram at all, return 600.
+        If there are no values in the histogram at all, return ``MAX_ACK_DEADLINE``.
 
         Returns:
             int: The maximum value in the histogram.
         """
         if len(self._data) == 0:
-            return 600
+            return MAX_ACK_DEADLINE
         return next(iter(reversed(sorted(self._data.keys()))))
 
     @property
     def min(self):
         """Return the minimum value in this histogram.
 
-        If there are no values in the histogram at all, return 10.
+        If there are no values in the histogram at all, return the min default.
 
         Returns:
             int: The minimum value in the histogram.
         """
         if len(self._data) == 0:
-            return 10
+            return MIN_ACK_DEADLINE
         return next(iter(sorted(self._data.keys())))
 
     def add(self, value):
         """Add the value to this histogram.
 
         Args:
-            value (int): The value. Values outside of ``10 <= x <= 600``
-                will be raised to ``10`` or reduced to ``600``.
+            value (int): The value. Values outside of
+            ``MIN_ACK_DEADLINE <= x <= MAX_ACK_DEADLINE``
+                will be raised to ``MIN_ACK_DEADLINE`` or reduced to
+                ``MAX_ACK_DEADLINE``.
         """
         # If the value is out of bounds, bring it in bounds.
         value = int(value)
-        if value < 10:
-            value = 10
-        if value > 600:
-            value = 600
+        if value < MIN_ACK_DEADLINE:
+            value = MIN_ACK_DEADLINE
+        elif value > MAX_ACK_DEADLINE:
+            value = MAX_ACK_DEADLINE
 
         # Add the value to the histogram's data dictionary.
         self._data.setdefault(value, 0)
@@ -129,7 +135,7 @@ class Histogram(object):
 
         Args:
             percent (Union[int, float]): The precentile being sought. The
-                default consumer implementations use consistently use ``99``.
+                default consumer implementations consistently use ``99``.
 
         Returns:
             int: The value corresponding to the requested percentile.
@@ -150,5 +156,5 @@ class Histogram(object):
                 return k
 
         # The only way to get here is if there was no data.
-        # In this case, just return 10 seconds.
-        return 10
+        # In this case, just return the shortest possible deadline.
+        return MIN_ACK_DEADLINE

--- a/google/cloud/pubsub_v1/subscriber/_protocol/histogram.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/histogram.py
@@ -31,8 +31,9 @@ class Histogram(object):
     are free to use a different formula.
 
     The precision of data stored is to the nearest integer. Additionally,
-    values outside the range of ``10 <= x <= 600`` are stored as ``10`` or
-    ``600``, since these are the boundaries of leases in the actual API.
+    values outside the range of ``MIN_ACK_DEADLINE <= x <= MAX_ACK_DEADLINE`` are stored
+    as ``MIN_ACK_DEADLINE`` or ``MAX_ACK_DEADLINE``, since these are the boundaries of
+    leases in the actual API.
     """
 
     def __init__(self, data=None):

--- a/google/cloud/pubsub_v1/subscriber/_protocol/histogram.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/histogram.py
@@ -100,7 +100,7 @@ class Histogram(object):
     def min(self):
         """Return the minimum value in this histogram.
 
-        If there are no values in the histogram at all, return the min default.
+        If there are no values in the histogram at all, return ``MIN_ACK_DEADLINE``.
 
         Returns:
             int: The minimum value in the histogram.

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -128,7 +128,9 @@ class Leaser(object):
             # Determine the appropriate duration for the lease. This is
             # based off of how long previous messages have taken to ack, with
             # a sensible default and within the ranges allowed by Pub/Sub.
-            deadline = self._manager.ack_deadline
+            # Also update the deadline currently used if enough new ACK data has been
+            # gathered since the last deadline update.
+            deadline = self._manager._obtain_ack_deadline(maybe_update=True)
             _LOGGER.debug("The current deadline value is %d seconds.", deadline)
 
             # Make a copy of the leased messages. This is needed because it's

--- a/google/cloud/pubsub_v1/types.py
+++ b/google/cloud/pubsub_v1/types.py
@@ -152,7 +152,8 @@ FlowControl.max_lease_duration.__doc__ = (
 FlowControl.max_duration_per_lease_extension.__doc__ = (
     "The max amount of time in seconds for a single lease extension attempt. "
     "Bounds the delay before a message redelivery if the subscriber "
-    "fails to extend the deadline."
+    "fails to extend the deadline. Must be between 10 and 600 (inclusive). Ignored "
+    "if set to 0."
 )
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_histogram.py
+++ b/tests/unit/pubsub_v1/subscriber/test_histogram.py
@@ -33,7 +33,7 @@ def test_contains():
 
 def test_max():
     histo = histogram.Histogram()
-    assert histo.max == 600
+    assert histo.max == histogram.MAX_ACK_DEADLINE
     histo.add(120)
     assert histo.max == 120
     histo.add(150)
@@ -44,7 +44,7 @@ def test_max():
 
 def test_min():
     histo = histogram.Histogram()
-    assert histo.min == 10
+    assert histo.min == histogram.MIN_ACK_DEADLINE
     histo.add(60)
     assert histo.min == 60
     histo.add(30)
@@ -63,20 +63,23 @@ def test_add():
 
 def test_add_lower_limit():
     histo = histogram.Histogram()
-    histo.add(5)
-    assert 5 not in histo
-    assert 10 in histo
+    low_value = histogram.MIN_ACK_DEADLINE - 1
+    histo.add(low_value)
+    assert low_value not in histo
+    assert histogram.MIN_ACK_DEADLINE in histo
 
 
 def test_add_upper_limit():
     histo = histogram.Histogram()
-    histo.add(12000)
-    assert 12000 not in histo
-    assert 600 in histo
+    high_value = histogram.MAX_ACK_DEADLINE + 1
+    histo.add(high_value)
+    assert high_value not in histo
+    assert histogram.MAX_ACK_DEADLINE in histo
 
 
 def test_percentile():
     histo = histogram.Histogram()
+    assert histo.percentile(42) == histogram.MIN_ACK_DEADLINE  # default when empty
     [histo.add(i) for i in range(101, 201)]
     assert histo.percentile(100) == 200
     assert histo.percentile(101) == 200

--- a/tests/unit/pubsub_v1/subscriber/test_leaser.py
+++ b/tests/unit/pubsub_v1/subscriber/test_leaser.py
@@ -84,7 +84,7 @@ def create_manager(flow_control=types.FlowControl()):
     manager.is_active = True
     manager.flow_control = flow_control
     manager.ack_histogram = histogram.Histogram()
-    manager.ack_deadline = 10
+    manager._obtain_ack_deadline.return_value = 10
     return manager
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -139,7 +139,7 @@ def fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=10):
     leaser.add = stdlib_types.MethodType(fake_add, leaser)
 
 
-def test_ack_deadline_no_custom_flow_control_setting():
+def test__obtain_ack_deadline_no_custom_flow_control_setting():
     from google.cloud.pubsub_v1.subscriber._protocol import histogram
 
     manager = make_manager()
@@ -147,18 +147,21 @@ def test_ack_deadline_no_custom_flow_control_setting():
     # Make sure that max_duration_per_lease_extension is disabled.
     manager._flow_control = types.FlowControl(max_duration_per_lease_extension=0)
 
-    assert manager.ack_deadline == histogram.MIN_ACK_DEADLINE
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MIN_ACK_DEADLINE
 
     # When we get some historical data, the deadline is adjusted.
     manager.ack_histogram.add(histogram.MIN_ACK_DEADLINE * 2)
-    assert manager.ack_deadline == histogram.MIN_ACK_DEADLINE * 2
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MIN_ACK_DEADLINE * 2
 
     # Adding just a single additional data point does not yet change the deadline.
     manager.ack_histogram.add(histogram.MIN_ACK_DEADLINE)
-    assert manager.ack_deadline == histogram.MIN_ACK_DEADLINE * 2
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MIN_ACK_DEADLINE * 2
 
 
-def test_ack_deadline_with_max_duration_per_lease_extension():
+def test__obtain_ack_deadline_with_max_duration_per_lease_extension():
     from google.cloud.pubsub_v1.subscriber._protocol import histogram
 
     manager = make_manager()
@@ -168,10 +171,11 @@ def test_ack_deadline_with_max_duration_per_lease_extension():
     manager.ack_histogram.add(histogram.MIN_ACK_DEADLINE * 3)  # make p99 value large
 
     # The deadline configured in flow control should prevail.
-    assert manager.ack_deadline == histogram.MIN_ACK_DEADLINE + 1
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MIN_ACK_DEADLINE + 1
 
 
-def test_ack_deadline_with_max_duration_per_lease_extension_too_low():
+def test__obtain_ack_deadline_with_max_duration_per_lease_extension_too_low():
     from google.cloud.pubsub_v1.subscriber._protocol import histogram
 
     manager = make_manager()
@@ -181,7 +185,32 @@ def test_ack_deadline_with_max_duration_per_lease_extension_too_low():
     manager.ack_histogram.add(histogram.MIN_ACK_DEADLINE * 3)  # make p99 value large
 
     # The deadline configured in flow control should be adjusted to the minimum allowed.
-    assert manager.ack_deadline == histogram.MIN_ACK_DEADLINE
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MIN_ACK_DEADLINE
+
+
+def test__obtain_ack_deadline_no_value_update():
+    manager = make_manager()
+
+    # Make sure that max_duration_per_lease_extension is disabled.
+    manager._flow_control = types.FlowControl(max_duration_per_lease_extension=0)
+
+    manager.ack_histogram.add(21)
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == 21
+
+    for _ in range(5):
+        manager.ack_histogram.add(35)  # Gather some new ACK data.
+
+    deadline = manager._obtain_ack_deadline(maybe_update=False)
+    assert deadline == 21  # still the same
+
+    # Accessing the value through the ack_deadline property has no side effects either.
+    assert manager.ack_deadline == 21
+
+    # Updating the ack deadline is reflected on ack_deadline wrapper, too.
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert manager.ack_deadline == deadline == 35
 
 
 def test_client_id():


### PR DESCRIPTION
Fixes #413.

This PR makes sure that the ACK deadline set for the received messages is always consistent with what the leaser uses internally when extending the ACK deadlines for the leased messages.

See the issue description and a [comment](https://github.com/googleapis/python-pubsub/issues/413#issuecomment-844995852) explaining a possible sequence of events that lead to a bug.

**PR checklist**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


