### PR TITLE
fix: threads can skip the line in publisher flow controller

### DIFF
--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -434,7 +434,7 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
         pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
     # Intentionally corrupt internal stats
-    reservation = next(iter(flow_controller._reservations.values()), None)
+    reservation = next(iter(flow_controller._waiting.values()), None)
     assert reservation is not None, "No messages blocked by flow controller."
     reservation.bytes_reserved = reservation.bytes_needed + 1
 

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -434,9 +434,9 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
         pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
     # Intentionally corrupt internal stats
-    reservation = next(iter(flow_controller._byte_reservations.values()), None)
+    reservation = next(iter(flow_controller._reservations.values()), None)
     assert reservation is not None, "No messages blocked by flow controller."
-    reservation.reserved = reservation.needed + 1
+    reservation.bytes_reserved = reservation.bytes_needed + 1
 
     with warnings.catch_warnings(record=True) as warned:
         _run_in_daemon(flow_controller.release, [msg1], releasing_1_done)

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -16,10 +16,14 @@ from __future__ import absolute_import
 
 import threading
 import time
+from typing import Callable
+from typing import Sequence
+from typing import Union
 import warnings
 
 import pytest
 
+import google
 from google.cloud.pubsub_v1 import types
 from google.cloud.pubsub_v1.publisher import exceptions
 from google.cloud.pubsub_v1.publisher.flow_controller import FlowController
@@ -27,25 +31,20 @@ from google.pubsub_v1 import types as grpc_types
 
 
 def _run_in_daemon(
-    flow_controller,
-    action,
-    messages,
-    all_done_event,
-    error_event=None,
-    action_pause=None,
+    action: Callable[["google.cloud.pubsub_v1.types.PubsubMessage"], None],
+    messages: Sequence["google.cloud.pubsub_v1.types.PubsubMessage"],
+    all_done_event: threading.Event,
+    error_event: threading.Event = None,
+    action_pause: Union[int, float] = None,
 ):
-    """Run flow controller action (add or remove messages) in a daemon thread.
-    """
-    assert action in ("add", "release")
+    """Run flow controller action (add or remove messages) in a daemon thread."""
 
     def run_me():
-        method = getattr(flow_controller, action)
-
         try:
             for msg in messages:
                 if action_pause is not None:
                     time.sleep(action_pause)
-                method(msg)
+                action(msg)
         except Exception:
             if error_event is not None:  # pragma: NO COVER
                 error_event.set()
@@ -227,7 +226,7 @@ def test_blocking_on_overflow_until_free_capacity():
     releasing_x_done = threading.Event()
 
     # Adding a message with free capacity should not block.
-    _run_in_daemon(flow_controller, "add", [msg1], adding_1_done)
+    _run_in_daemon(flow_controller.add, [msg1], adding_1_done)
     if not adding_1_done.wait(timeout=0.1):
         pytest.fail(  # pragma: NO COVER
             "Adding a message with enough flow capacity blocked or errored."
@@ -235,21 +234,21 @@ def test_blocking_on_overflow_until_free_capacity():
 
     # Adding messages when there is not enough capacity should block, even if
     # added through multiple threads.
-    _run_in_daemon(flow_controller, "add", [msg2], adding_2_done)
+    _run_in_daemon(flow_controller.add, [msg2], adding_2_done)
     if adding_2_done.wait(timeout=0.1):
         pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
-    _run_in_daemon(flow_controller, "add", [msg3], adding_3_done)
+    _run_in_daemon(flow_controller.add, [msg3], adding_3_done)
     if adding_3_done.wait(timeout=0.1):
         pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
-    _run_in_daemon(flow_controller, "add", [msg4], adding_4_done)
+    _run_in_daemon(flow_controller.add, [msg4], adding_4_done)
     if adding_4_done.wait(timeout=0.1):
         pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
     # After releasing one message, there should be room for a new message, which
     # should result in unblocking one of the waiting threads.
-    _run_in_daemon(flow_controller, "release", [msg1], releasing_1_done)
+    _run_in_daemon(flow_controller.release, [msg1], releasing_1_done)
     if not releasing_1_done.wait(timeout=0.1):
         pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER
 
@@ -266,7 +265,7 @@ def test_blocking_on_overflow_until_free_capacity():
 
     # Release another message and verify that yet another thread gets unblocked.
     added_msg = [msg2, msg3, msg4][done_status.index(True)]
-    _run_in_daemon(flow_controller, "release", [added_msg], releasing_x_done)
+    _run_in_daemon(flow_controller.release, [added_msg], releasing_x_done)
 
     if not releasing_x_done.wait(timeout=0.1):
         pytest.fail("Releasing messages blocked or errored.")  # pragma: NO COVER
@@ -293,7 +292,7 @@ def test_error_if_mesage_would_block_indefinitely():
     adding_done = threading.Event()
     error_event = threading.Event()
 
-    _run_in_daemon(flow_controller, "add", [msg], adding_done, error_event=error_event)
+    _run_in_daemon(flow_controller.add, [msg], adding_done, error_event=error_event)
 
     assert error_event.wait(timeout=0.1), "No error on adding too large a message."
 
@@ -329,20 +328,20 @@ def test_threads_posting_large_messages_do_not_starve():
     # enough messages should eventually allow the large message to come through, even
     # if more messages are added after it (those should wait for the large message).
     initial_messages = [grpc_types.PubsubMessage(data=b"x" * 10)] * 5
-    _run_in_daemon(flow_controller, "add", initial_messages, adding_initial_done)
+    _run_in_daemon(flow_controller.add, initial_messages, adding_initial_done)
     assert adding_initial_done.wait(timeout=0.1)
 
-    _run_in_daemon(flow_controller, "add", [large_msg], adding_large_done)
+    _run_in_daemon(flow_controller.add, [large_msg], adding_large_done)
 
     # Continuously keep adding more messages after the large one.
     messages = [grpc_types.PubsubMessage(data=b"x" * 10)] * 10
-    _run_in_daemon(flow_controller, "add", messages, adding_busy_done, action_pause=0.1)
+    _run_in_daemon(flow_controller.add, messages, adding_busy_done, action_pause=0.1)
 
     # At the same time, gradually keep releasing the messages - the freeed up
     # capacity should be consumed by the large message, not the other small messages
     # being added after it.
     _run_in_daemon(
-        flow_controller, "release", messages, releasing_busy_done, action_pause=0.1
+        flow_controller.release, messages, releasing_busy_done, action_pause=0.1
     )
 
     # Sanity check - releasing should have completed by now.
@@ -359,7 +358,7 @@ def test_threads_posting_large_messages_do_not_starve():
 
     # Releasing the large message should unblock adding the remaining "busy" messages
     # that have not been added yet.
-    _run_in_daemon(flow_controller, "release", [large_msg], releasing_large_done)
+    _run_in_daemon(flow_controller.release, [large_msg], releasing_large_done)
     if not releasing_large_done.wait(timeout=0.1):
         pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER
 
@@ -384,7 +383,7 @@ def test_blocked_messages_are_accepted_in_fifo_order():
 
     # Add messages. The first one will be accepted, and the rest should queue behind.
     for adding_done in adding_done_events:
-        _run_in_daemon(flow_controller, "add", [message], adding_done)
+        _run_in_daemon(flow_controller.add, [message], adding_done)
         time.sleep(0.1)
 
     if not adding_done_events[0].wait(timeout=0.1):  # pragma: NO COVER
@@ -397,7 +396,7 @@ def test_blocked_messages_are_accepted_in_fifo_order():
         if not adding_done.wait(timeout=0.1):  # pragma: NO COVER
             pytest.fail(f"Queued message still blocked on adding (i={i}).")
 
-        _run_in_daemon(flow_controller, "release", [message], releasing_done)
+        _run_in_daemon(flow_controller.release, [message], releasing_done)
         if not releasing_done.wait(timeout=0.1):  # pragma: NO COVER
             pytest.fail(f"Queued message was not released in time (i={i}).")
 
@@ -422,7 +421,7 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
     releasing_1_done = threading.Event()
 
     # Adding a message with free capacity should not block.
-    _run_in_daemon(flow_controller, "add", [msg1], adding_1_done)
+    _run_in_daemon(flow_controller.add, [msg1], adding_1_done)
     if not adding_1_done.wait(timeout=0.1):
         pytest.fail(  # pragma: NO COVER
             "Adding a message with enough flow capacity blocked or errored."
@@ -430,7 +429,7 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
 
     # Adding messages when there is not enough capacity should block, even if
     # added through multiple threads.
-    _run_in_daemon(flow_controller, "add", [msg2], adding_2_done)
+    _run_in_daemon(flow_controller.add, [msg2], adding_2_done)
     if adding_2_done.wait(timeout=0.1):
         pytest.fail("Adding a message on overflow did not block.")  # pragma: NO COVER
 
@@ -440,7 +439,7 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
     reservation.reserved = reservation.needed + 1
 
     with warnings.catch_warnings(record=True) as warned:
-        _run_in_daemon(flow_controller, "release", [msg1], releasing_1_done)
+        _run_in_daemon(flow_controller.release, [msg1], releasing_1_done)
         if not releasing_1_done.wait(timeout=0.1):
             pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER
 


### PR DESCRIPTION
Fixes #421.

Contrary to the bytes reservations, free message slots are not distributed in FIFO order among the waiting threads, meaning that a message arriving later could be accepted before a message already waiting in the queue.

This PR fixes it by enforcing FIFO distribution of available message slots + some simplifications of the logic and data structures.

**Tip:** Might be easier to review commit-by-commit, each contains a well-rounded change to the codebase.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

