### PR TITLE
test: gather status code after pytest

### DIFF
--- a/.kokoro/presubmit-against-pubsublite-samples.sh
+++ b/.kokoro/presubmit-against-pubsublite-samples.sh
@@ -84,10 +84,10 @@ for file in python-pubsublite/samples/**/requirements.txt; do
     # Install python-pubsub from source.
     python -m pip install -e "$ROOT" -q
     python -m pytest quickstart_test.py
+    EXIT=$?
+    
     deactivate py-3.6
     rm -rf py-3.6/
-
-    EXIT=$?
 
     if [[ $EXIT -ne 0 ]]; then
       RTN=1


### PR DESCRIPTION
As @plamut rightly pointed out, `EXIT=$` needs to be placed right after `pytest`. 

https://github.com/googleapis/python-pubsub/pull/425#discussion_r650695456