### PR TITLE
samples: publish with error handler and flow control

### DIFF
--- a/samples/snippets/publisher.py
+++ b/samples/snippets/publisher.py
@@ -150,8 +150,8 @@ def publish_messages_with_error_handler(project_id, topic_id):
     def get_callback(publish_future, data):
         def callback(publish_future):
             try:
-                # Wait 100 ms for the publish call to succeed.
-                print(publish_future.result(timeout=0.1))
+                # Wait 60 seconds for the publish call to succeed.
+                print(publish_future.result(timeout=60))
             except futures.TimeoutError:
                 print(f"Publishing {data} timed out.")
 
@@ -246,7 +246,8 @@ def publish_messages_with_flow_control_settings(project_id, topic_id):
         message_id = publish_future.result()
         print(message_id)
 
-    # Publish 1000 messages in quick succession to trigger flow control.
+    # Publish 1000 messages in quick succession may be constrained by
+    # publisher flow control.
     for n in range(1, 1000):
         data = f"Message number {n}"
         # Data must be a bytestring


### PR DESCRIPTION
Address @kamalaboulhosn 's comments in #717

The goal of the sample `pubsub_publish_with_error_handler` is to show how to handle publish failures. In the current iteration, I want to show how to catch and handle `TimeoutError`. I know using a generic exception isn't generally recommended by samples rubrics. Let me know if you see a better type of error to catch in this sample.