### PR TITLE
samples(test): flaky sync pull test

### DIFF
--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -477,6 +477,11 @@ def test_receive_synchronously_with_lease(
     @backoff.on_exception(backoff.expo, Unknown, max_time=300)
     def run_sample():
         _publish_messages(publisher_client, topic, message_num=10)
+        # Pausing 10s to allow the subscriber to establish the connection
+        # because sync pull often returns fewer messages than requested.
+        # The intention is to fix flaky tests reporting errors like
+        # `google.api_core.exceptions.Unknown: None Stream removed` as
+        # in https://github.com/googleapis/python-pubsub/issues/341.
         time.sleep(10)
         subscriber.synchronous_pull_with_lease_management(PROJECT_ID, SUBSCRIPTION_SYNC)
 

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -15,6 +15,7 @@
 import os
 import re
 import sys
+import time
 import uuid
 
 import backoff
@@ -475,7 +476,8 @@ def test_receive_synchronously_with_lease(
 ):
     @backoff.on_exception(backoff.expo, Unknown, max_time=300)
     def run_sample():
-        _publish_messages(publisher_client, topic, message_num=3)
+        _publish_messages(publisher_client, topic, message_num=10)
+        time.sleep(10)
         subscriber.synchronous_pull_with_lease_management(PROJECT_ID, SUBSCRIPTION_SYNC)
 
     run_sample()


### PR DESCRIPTION
Fixes #341 🦕

The stream sometimes gets removed (`UNKNOWN` errors) before the subscriber can successfully pull messages. Pausing to give the subscriber some time to reconnect since this subscription (`subscription_sync`) is used in two different synchronous pull samples:
- test_receive_synchronously_with_lease
- test_receive_synchronously

If this doesn't fix the flaky test, I will consider using two different subscriptions for the two different sync pull samples tests.

The delete schema sample test failure is unrelated. It's known and is flaky due to backend issues. 
