### PR TITLE
fix: require grpcio >= 1.38.1 to prevent a possible crash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ version = "2.6.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
+    "grpcio >= 1.38.1, < 2.0dev",  # https://github.com/googleapis/python-pubsub/issues/414
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "libcst >= 0.3.10",
     "proto-plus >= 1.7.1",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,6 +5,7 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
+grpcio==1.38.1
 google-api-core==1.22.2
 libcst==0.3.10
 proto-plus==1.7.1


### PR DESCRIPTION
Fixes #414.

See the issue [comment](https://github.com/googleapis/python-pubsub/issues/414#issuecomment-856452925) for more info.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


