### PR TITLE
docs: include docs for Pager classes

### DIFF
--- a/docs/publisher/api/pagers.rst
+++ b/docs/publisher/api/pagers.rst
@@ -1,0 +1,6 @@
+Pagers
+======
+
+.. automodule:: google.pubsub_v1.services.publisher.pagers
+  :members:
+  :inherited-members:

--- a/docs/publisher/index.rst
+++ b/docs/publisher/index.rst
@@ -172,3 +172,4 @@ API Reference
 
   api/client
   api/futures
+  api/pagers

--- a/docs/subscriber/api/pagers.rst
+++ b/docs/subscriber/api/pagers.rst
@@ -1,0 +1,6 @@
+Pagers
+======
+
+.. automodule:: google.pubsub_v1.services.subscriber.pagers
+  :members:
+  :inherited-members:

--- a/docs/subscriber/index.rst
+++ b/docs/subscriber/index.rst
@@ -232,4 +232,5 @@ API Reference
   api/client
   api/message
   api/futures
+  api/pagers
   api/scheduler


### PR DESCRIPTION
Fixes #436.

This PR makes sure that the docs for `*Pager` classes are generated and cross-linked in the docs for methods that return them.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


