### PR TITLE
chore: use public post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -1,3 +1,3 @@
 docker:
-  digest: sha256:0ffe3bdd6c7159692df5f7744da74e5ef19966288a6bf76023e8e04e0c424d7d
-  image: gcr.io/repo-automation-bots/owlbot-python:latest
+  image: gcr.io/cloud-devrel-public-resources/owlbot-python:latest
+  digest: sha256:a3a85c2e0b3293068e47b1635b178f7e3d3845f2cfb8722de6713d4bbafdcd1d

--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 docker:
-  image: gcr.io/repo-automation-bots/owlbot-python:latest
+  image: gcr.io/cloud-devrel-public-resources/owlbot-python:latest
 
 deep-remove-regex:
   - /owl-bot-staging


### PR DESCRIPTION
The issue with owlbot mentioned in #492 is fixed. I'd like to switch back to using the public post processor image.

This PR migrates from using a private post processor image `gcr.io/repo-automation-bots/owlbot-python:latest` to a public one `gcr.io/cloud-devrel-public-resources/owlbot-python:latest` which is used by automation to update templated files across python repositories in the googleapis org.

Use the following commands to test the feature:
```
# Pull the latest python post processor image `gcr.io/cloud-devrel-public-resources/owlbot-python`
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```

```
# Read the digest of the post processor image `gcr.io/cloud-devrel-public-resources/owlbot-python` with the tag `latest`
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python:latest 
```

```
# In the root of the repo, use this command to run the public post processor image 
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```

The benefit is that external maintainers should now be able to run the post-processor locally and PRs should continue to be opened by automation when there are updates to templated files.

I tested the functionality in the python-datastream repository and it seems to be working correctly. If there is any issue , we can roll back to the private post processor image.