### PR TITLE
ci: harden schema sample teardown against 500 InternalServiceError

### DIFF
--- a/samples/snippets/schema_test.py
+++ b/samples/snippets/schema_test.py
@@ -20,9 +20,12 @@ import uuid
 
 from _pytest.capture import CaptureFixture
 from flaky import flaky
+from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import NotFound
 from google.cloud import pubsub_v1
-from google.cloud.pubsub import PublisherClient, SchemaServiceClient, SubscriberClient
+from google.cloud.pubsub import PublisherClient
+from google.cloud.pubsub import SchemaServiceClient
+from google.cloud.pubsub import SubscriberClient
 from google.pubsub_v1.types import Encoding
 import pytest
 
@@ -59,7 +62,7 @@ def avro_schema(
 
     try:
         schema_client.delete_schema(request={"name": avro_schema_path})
-    except NotFound:
+    except (NotFound, InternalServerError):
         pass
 
 
@@ -73,7 +76,7 @@ def proto_schema(
 
     try:
         schema_client.delete_schema(request={"name": proto_schema_path})
-    except NotFound:
+    except (NotFound, InternalServerError):
         pass
 
 


### PR DESCRIPTION
Closes #388.