### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "pubsub",
     "name_pretty": "Google Cloud Pub/Sub",
     "product_documentation": "https://cloud.google.com/pubsub/docs/",
-    "client_documentation": "https://googleapis.dev/python/pubsub/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/pubsub/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559741",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ independently written applications.
    :target: https://pypi.org/project/google-cloud-pubsub/
 .. _Google Cloud Pub / Sub: https://cloud.google.com/pubsub/
 .. _Product Documentation: https://cloud.google.com/pubsub/docs
-.. _Client Library Documentation: https://googleapis.dev/python/pubsub/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/pubsub/latest
 
 Quick Start
 -----------
@@ -116,7 +116,7 @@ messages to it
 
 To learn more, consult the `publishing documentation`_.
 
-.. _publishing documentation: https://googleapis.dev/python/pubsub/latest
+.. _publishing documentation: https://cloud.google.com/python/docs/reference/pubsub/latest
 
 
 Subscribing
@@ -162,7 +162,7 @@ block the current thread until a given condition obtains:
 It is also possible to pull messages in a synchronous (blocking) fashion. To
 learn more about subscribing, consult the `subscriber documentation`_.
 
-.. _subscriber documentation: https://googleapis.dev/python/pubsub/latest
+.. _subscriber documentation: https://cloud.google.com/python/docs/reference/pubsub/latest
 
 
 Authentication


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.