### PR TITLE
process: make sure type annoations pass with mypy

### DIFF
--- a/google/cloud/__init__.py
+++ b/google/cloud/__init__.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
+
 try:
     import pkg_resources
 
@@ -21,4 +23,6 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__ = pkgutil.extend_path(__path__, __name__)
+    __path__: List[str] = pkgutil.extend_path(
+        __path__, __name__
+    )  # pytype: disable=annotation-type-mismatch

--- a/google/cloud/__init__.py
+++ b/google/cloud/__init__.py
@@ -23,6 +23,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: List[str] = pkgutil.extend_path(
-        __path__, __name__
-    )  # pytype: disable=annotation-type-mismatch
+    __path__: List[str] = pkgutil.extend_path(__path__, __name__)  # type: ignore

--- a/google/cloud/pubsub_v1/futures.py
+++ b/google/cloud/pubsub_v1/futures.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 
 import concurrent.futures
-from typing import Any, NoReturn
+from typing import Any, NoReturn, Optional
 
 import google.api_core.future
 
@@ -47,7 +47,7 @@ class Future(concurrent.futures.Future, google.api_core.future.Future):
         """
         return super().set_result(result=result)
 
-    def set_exception(self, exception: Exception):
+    def set_exception(self, exception: Optional[BaseException]):
         """Set the result of the future as being the given exception.
 
         Do not use this method, it should only be used internally by the library and its

--- a/google/cloud/pubsub_v1/publisher/_batch/base.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/base.py
@@ -58,7 +58,7 @@ class Batch(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def make_lock() -> None:  # pragma: NO COVER
+    def make_lock():  # pragma: NO COVER
         """Return a lock in the chosen concurrency model.
 
         Returns:

--- a/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -18,7 +18,7 @@ import logging
 import threading
 import time
 import typing
-from typing import Any, Callable, List, Optional, Sequence, Union
+from typing import Any, Callable, List, Optional, Sequence
 
 import google.api_core.exceptions
 from google.api_core import gapic_v1
@@ -33,14 +33,11 @@ if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1.publisher import Client as PublisherClient
     from google.pubsub_v1.services.publisher.client import OptionalRetry
 
-
 _LOGGER = logging.getLogger(__name__)
 _CAN_COMMIT = (base.BatchStatus.ACCEPTING_MESSAGES, base.BatchStatus.STARTING)
 _SERVER_PUBLISH_MAX_BYTES = 10 * 1000 * 1000  # max accepted size of PublishRequest
 
 _raw_proto_pubbsub_message = gapic_types.PubsubMessage.pb()
-
-_TimeoutType = Union[gapic_types.TimeoutType, gapic_v1.method._MethodDefault]
 
 
 class Batch(base.Batch):
@@ -96,7 +93,7 @@ class Batch(base.Batch):
         batch_done_callback: Callable[[bool], Any] = None,
         commit_when_full: bool = True,
         commit_retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
-        commit_timeout: _TimeoutType = gapic_v1.method.DEFAULT,
+        commit_timeout: "types.OptionalTimeout" = gapic_v1.method.DEFAULT,
     ):
         self._client = client
         self._topic = topic

--- a/google/cloud/pubsub_v1/publisher/_sequencer/base.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/base.py
@@ -22,7 +22,7 @@ from google.pubsub_v1 import types as gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from concurrent import futures
-    from google.api_core import retry
+    from google.pubsub_v1.services.publisher.client import OptionalRetry
 
 
 class Sequencer(metaclass=abc.ABCMeta):
@@ -30,7 +30,6 @@ class Sequencer(metaclass=abc.ABCMeta):
        sequences messages to be published.
     """
 
-    @staticmethod
     @abc.abstractmethod
     def is_finished(self) -> bool:  # pragma: NO COVER
         """ Whether the sequencer is finished and should be cleaned up.
@@ -40,7 +39,6 @@ class Sequencer(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @staticmethod
     @abc.abstractmethod
     def unpause(self) -> None:  # pragma: NO COVER
         """ Unpauses this sequencer.
@@ -51,12 +49,11 @@ class Sequencer(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @staticmethod
     @abc.abstractmethod
     def publish(
         self,
         message: gapic_types.PubsubMessage,
-        retry: "retry.Retry" = None,
+        retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
         timeout: gapic_types.TimeoutType = gapic_v1.method.DEFAULT,
     ) -> "futures.Future":  # pragma: NO COVER
         """ Publish message for this ordering key.

--- a/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
@@ -290,12 +290,12 @@ class OrderedSequencer(sequencer_base.Sequencer):
         """
         with self._state_lock:
             if self._state == _OrderedSequencerStatus.PAUSED:
-                future: Optional[futures.Future] = futures.Future()
+                errored_future = futures.Future()
                 exception = exceptions.PublishToPausedOrderingKeyException(
                     self._ordering_key
                 )
-                cast(futures.Future, future).set_exception(exception)
-                return cast(futures.Future, future)
+                errored_future.set_exception(exception)
+                return errored_future
 
             # If waiting to be cleaned-up, convert to accepting messages to
             # prevent this sequencer from being cleaned-up only to have another

--- a/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
@@ -16,7 +16,7 @@ import enum
 import collections
 import threading
 import typing
-from typing import cast, Deque, Iterable, Optional, Sequence, Union
+from typing import cast, Deque, Iterable, Optional, Sequence
 
 from google.api_core import gapic_v1
 from google.cloud.pubsub_v1.publisher import futures
@@ -26,12 +26,10 @@ from google.cloud.pubsub_v1.publisher._batch import base as batch_base
 from google.pubsub_v1 import types as gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
+    from google.cloud.pubsub_v1 import types
     from google.cloud.pubsub_v1.publisher import _batch
     from google.cloud.pubsub_v1.publisher.client import Client as PublisherClient
     from google.pubsub_v1.services.publisher.client import OptionalRetry
-
-
-_TimeoutType = Union[gapic_types.TimeoutType, gapic_v1.method._MethodDefault]
 
 
 class _OrderedSequencerStatus(str, enum.Enum):
@@ -241,7 +239,7 @@ class OrderedSequencer(sequencer_base.Sequencer):
     def _create_batch(
         self,
         commit_retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
-        commit_timeout: _TimeoutType = gapic_v1.method.DEFAULT,
+        commit_timeout: "types.OptionalTimeout" = gapic_v1.method.DEFAULT,
     ) -> "_batch.thread.Batch":
         """ Create a new batch using the client's batch class and other stored
             settings.
@@ -266,7 +264,7 @@ class OrderedSequencer(sequencer_base.Sequencer):
         self,
         message: gapic_types.PubsubMessage,
         retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
-        timeout: _TimeoutType = gapic_v1.method.DEFAULT,
+        timeout: "types.OptionalTimeout" = gapic_v1.method.DEFAULT,
     ) -> futures.Future:
         """ Publish message for this ordering key.
 

--- a/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
@@ -14,21 +14,24 @@
 
 import enum
 import collections
-import concurrent.futures as futures
 import threading
 import typing
-from typing import Iterable, Sequence
+from typing import cast, Deque, Iterable, Optional, Sequence, Union
 
 from google.api_core import gapic_v1
+from google.cloud.pubsub_v1.publisher import futures
 from google.cloud.pubsub_v1.publisher import exceptions
 from google.cloud.pubsub_v1.publisher._sequencer import base as sequencer_base
 from google.cloud.pubsub_v1.publisher._batch import base as batch_base
 from google.pubsub_v1 import types as gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
-    from google.api_core import retry
-    from google.cloud.pubsub_v1 import PublisherClient
     from google.cloud.pubsub_v1.publisher import _batch
+    from google.cloud.pubsub_v1.publisher.client import Client as PublisherClient
+    from google.pubsub_v1.services.publisher.client import OptionalRetry
+
+
+_TimeoutType = Union[gapic_types.TimeoutType, gapic_v1.method._MethodDefault]
 
 
 class _OrderedSequencerStatus(str, enum.Enum):
@@ -101,7 +104,7 @@ class OrderedSequencer(sequencer_base.Sequencer):
         # Batches ordered from first (head/left) to last (right/tail).
         # Invariant: always has at least one batch after the first publish,
         # unless paused or stopped.
-        self._ordered_batches = collections.deque()
+        self._ordered_batches: Deque["_batch.thread.Batch"] = collections.deque()
         # See _OrderedSequencerStatus for valid state transitions.
         self._state = _OrderedSequencerStatus.ACCEPTING_MESSAGES
 
@@ -237,8 +240,8 @@ class OrderedSequencer(sequencer_base.Sequencer):
 
     def _create_batch(
         self,
-        commit_retry: "retry.Retry" = gapic_v1.method.DEFAULT,
-        commit_timeout: gapic_types.TimeoutType = gapic_v1.method.DEFAULT,
+        commit_retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
+        commit_timeout: _TimeoutType = gapic_v1.method.DEFAULT,
     ) -> "_batch.thread.Batch":
         """ Create a new batch using the client's batch class and other stored
             settings.
@@ -262,8 +265,8 @@ class OrderedSequencer(sequencer_base.Sequencer):
     def publish(
         self,
         message: gapic_types.PubsubMessage,
-        retry: "retry.Retry" = gapic_v1.method.DEFAULT,
-        timeout: gapic_types.TimeoutType = gapic_v1.method.DEFAULT,
+        retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
+        timeout: _TimeoutType = gapic_v1.method.DEFAULT,
     ) -> futures.Future:
         """ Publish message for this ordering key.
 
@@ -289,12 +292,12 @@ class OrderedSequencer(sequencer_base.Sequencer):
         """
         with self._state_lock:
             if self._state == _OrderedSequencerStatus.PAUSED:
-                future = futures.Future()
+                future: Optional[futures.Future] = futures.Future()
                 exception = exceptions.PublishToPausedOrderingKeyException(
                     self._ordering_key
                 )
-                future.set_exception(exception)
-                return future
+                cast(futures.Future, future).set_exception(exception)
+                return cast(futures.Future, future)
 
             # If waiting to be cleaned-up, convert to accepting messages to
             # prevent this sequencer from being cleaned-up only to have another

--- a/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py
@@ -16,7 +16,7 @@ import enum
 import collections
 import threading
 import typing
-from typing import cast, Deque, Iterable, Optional, Sequence
+from typing import Deque, Iterable, Sequence
 
 from google.api_core import gapic_v1
 from google.cloud.pubsub_v1.publisher import futures

--- a/google/cloud/pubsub_v1/publisher/_sequencer/unordered_sequencer.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/unordered_sequencer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import typing
-from typing import Optional, Union
+from typing import Optional
 
 from google.api_core import gapic_v1
 
@@ -26,8 +26,7 @@ if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1.publisher.client import Client as PublisherClient
     from google.pubsub_v1.services.publisher.client import OptionalRetry
 
-
-_TimeoutType = Union[gapic_types.TimeoutType, gapic_v1.method._MethodDefault]
+    from google.cloud.pubsub_v1 import types
 
 
 class UnorderedSequencer(base.Sequencer):
@@ -93,7 +92,7 @@ class UnorderedSequencer(base.Sequencer):
     def _create_batch(
         self,
         commit_retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
-        commit_timeout: _TimeoutType = gapic_v1.method.DEFAULT,
+        commit_timeout: "types.OptionalTimeout" = gapic_v1.method.DEFAULT,
     ) -> "_batch.thread.Batch":
         """ Create a new batch using the client's batch class and other stored
             settings.
@@ -118,7 +117,7 @@ class UnorderedSequencer(base.Sequencer):
         self,
         message: gapic_types.PubsubMessage,
         retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
-        timeout: _TimeoutType = gapic_v1.method.DEFAULT,
+        timeout: "types.OptionalTimeout" = gapic_v1.method.DEFAULT,
     ) -> "futures.Future":
         """ Batch message into existing or new batch.
 

--- a/google/cloud/pubsub_v1/publisher/_sequencer/unordered_sequencer.py
+++ b/google/cloud/pubsub_v1/publisher/_sequencer/unordered_sequencer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import typing
+from typing import Optional, Union
 
 from google.api_core import gapic_v1
 
@@ -20,10 +21,13 @@ from google.cloud.pubsub_v1.publisher._sequencer import base
 from google.pubsub_v1 import types as gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
-    from concurrent import futures
-    from google.api_core import retry
-    from google.cloud.pubsub_v1 import PublisherClient
     from google.cloud.pubsub_v1.publisher import _batch
+    from google.cloud.pubsub_v1.publisher import futures
+    from google.cloud.pubsub_v1.publisher.client import Client as PublisherClient
+    from google.pubsub_v1.services.publisher.client import OptionalRetry
+
+
+_TimeoutType = Union[gapic_types.TimeoutType, gapic_v1.method._MethodDefault]
 
 
 class UnorderedSequencer(base.Sequencer):
@@ -35,7 +39,7 @@ class UnorderedSequencer(base.Sequencer):
     def __init__(self, client: "PublisherClient", topic: str):
         self._client = client
         self._topic = topic
-        self._current_batch = None
+        self._current_batch: Optional["_batch.thread.Batch"] = None
         self._stopped = False
 
     def is_finished(self) -> bool:
@@ -88,8 +92,8 @@ class UnorderedSequencer(base.Sequencer):
 
     def _create_batch(
         self,
-        commit_retry: "retry.Retry" = gapic_v1.method.DEFAULT,
-        commit_timeout: gapic_types.TimeoutType = gapic_v1.method.DEFAULT,
+        commit_retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
+        commit_timeout: _TimeoutType = gapic_v1.method.DEFAULT,
     ) -> "_batch.thread.Batch":
         """ Create a new batch using the client's batch class and other stored
             settings.
@@ -113,8 +117,8 @@ class UnorderedSequencer(base.Sequencer):
     def publish(
         self,
         message: gapic_types.PubsubMessage,
-        retry: "retry.Retry" = gapic_v1.method.DEFAULT,
-        timeout: gapic_types.TimeoutType = gapic_v1.method.DEFAULT,
+        retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
+        timeout: _TimeoutType = gapic_v1.method.DEFAULT,
     ) -> "futures.Future":
         """ Batch message into existing or new batch.
 

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -46,7 +46,6 @@ except pkg_resources.DistributionNotFound:
     __version__ = "0.0"
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
-    from google import api_core
     from google.cloud import pubsub_v1
     from google.cloud.pubsub_v1.publisher import _batch
     from google.pubsub_v1.services.publisher.client import OptionalRetry

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -384,11 +384,10 @@ class Client(object):
                 if retry is gapic_v1.method.DEFAULT:
                     # use the default retry for the publish GRPC method as a base
                     transport = self.api._transport
-                    retry = typing.cast(
-                        "api_core.retry.Retry",
-                        transport._wrapped_methods[transport.publish]._retry,
-                    )
-                retry = retry.with_deadline(2.0 ** 32)
+                    base_retry = transport._wrapped_methods[transport.publish]._retry
+                    retry = base_retry.with_deadline(2.0 ** 32)
+                else:
+                    retry = retry.with_deadline(2.0 ** 32)
 
             # Delegate the publishing to the sequencer.
             sequencer = self._get_or_create_sequencer(topic, ordering_key)

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -62,7 +62,6 @@ _DENYLISTED_METHODS = (
 
 _raw_proto_pubbsub_message = gapic_types.PubsubMessage.pb()
 
-_TimeoutType = Union[gapic_types.TimeoutType, gapic_v1.method._MethodDefault]
 SequencerType = Union[
     ordered_sequencer.OrderedSequencer, unordered_sequencer.UnorderedSequencer
 ]
@@ -260,7 +259,7 @@ class Client(object):
         data: bytes,
         ordering_key: str = "",
         retry: "OptionalRetry" = gapic_v1.method.DEFAULT,
-        timeout: _TimeoutType = gapic_v1.method.DEFAULT,
+        timeout: "types.OptionalTimeout" = gapic_v1.method.DEFAULT,
         **attrs: Union[bytes, str],
     ) -> "pubsub_v1.publisher.futures.Future":
         """Publish a single message.

--- a/google/cloud/pubsub_v1/publisher/client.py
+++ b/google/cloud/pubsub_v1/publisher/client.py
@@ -24,8 +24,8 @@ import typing
 from typing import Any, Sequence, Type, Union
 
 from google.api_core import gapic_v1
-from google.auth.credentials import AnonymousCredentials
-from google.oauth2 import service_account
+from google.auth.credentials import AnonymousCredentials  # type: ignore
+from google.oauth2 import service_account  # type: ignore
 
 from google.cloud.pubsub_v1 import _gapic
 from google.cloud.pubsub_v1 import types

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -21,6 +21,7 @@ import math
 import threading
 import typing
 from typing import List, Optional, Sequence, Union
+import warnings
 
 from google.cloud.pubsub_v1.subscriber._protocol import helper_threads
 from google.cloud.pubsub_v1.subscriber._protocol import requests
@@ -128,6 +129,11 @@ class Dispatcher(object):
                 nack_requests.append(item)
             elif isinstance(item, requests.DropRequest):
                 drop_requests.append(item)
+            else:
+                warnings.warn(
+                    f'Skipping unknown request item of type "{type(item)}"',
+                    category=RuntimeWarning,
+                )
 
         _LOGGER.debug("Handling %d batched requests", len(items))
 

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -191,8 +191,8 @@ class Dispatcher(object):
         Args:
             items: The items to drop.
         """
-        leaser = cast("Leaser", self._manager.leaser)
-        leaser.remove(items)
+        assert self._manager.leaser is not None
+        self._manager.leaser.remove(items)
         ordering_keys = (k.ordering_key for k in items if k.ordering_key)
         self._manager.activate_ordering_keys(ordering_keys)
         self._manager.maybe_resume_consumer()

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -20,7 +20,7 @@ import logging
 import math
 import threading
 import typing
-from typing import cast, List, Optional, Sequence, Union
+from typing import List, Optional, Sequence, Union
 
 from google.cloud.pubsub_v1.subscriber._protocol import helper_threads
 from google.cloud.pubsub_v1.subscriber._protocol import requests
@@ -28,7 +28,6 @@ from google.pubsub_v1 import types as gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     import queue
-    from google.cloud.pubsub_v1.subscriber._protocol.leaser import Leaser
     from google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager import (
         StreamingPullManager,
     )
@@ -198,8 +197,8 @@ class Dispatcher(object):
         Args:
             items: The items to lease.
         """
-        leaser = cast("Leaser", self._manager.leaser)
-        leaser.add(items)
+        assert self._manager.leaser is not None
+        self._manager.leaser.add(items)
         self._manager.maybe_pause_consumer()
 
     def modify_ack_deadline(self, items: Sequence[requests.ModAckRequest]) -> None:

--- a/google/cloud/pubsub_v1/subscriber/_protocol/heartbeater.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/heartbeater.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 import logging
 import threading
 import typing
+from typing import Optional
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager import (
@@ -34,7 +35,7 @@ _DEFAULT_PERIOD = 30
 
 class Heartbeater(object):
     def __init__(self, manager: "StreamingPullManager", period: int = _DEFAULT_PERIOD):
-        self._thread = None
+        self._thread: Optional[threading.Thread] = None
         self._operational_lock = threading.Lock()
         self._manager = manager
         self._stop_event = threading.Event()

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -20,7 +20,7 @@ import random
 import threading
 import time
 import typing
-from typing import cast, Dict, Iterable, Optional, Union
+from typing import Dict, Iterable, Optional, Union
 
 try:
     from collections.abc import KeysView
@@ -33,7 +33,6 @@ except TypeError:
 from google.cloud.pubsub_v1.subscriber._protocol import requests
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
-    from google.cloud.pubsub_v1.subscriber._protocol.dispatcher import Dispatcher
     from google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager import (
         StreamingPullManager,
     )
@@ -173,8 +172,8 @@ class Leaser(object):
                 _LOGGER.warning(
                     "Dropping %s items because they were leased too long.", len(to_drop)
                 )
-                dispatcher = cast("Dispatcher", self._manager.dispatcher)
-                dispatcher.drop(to_drop)
+                assert self._manager.dispatcher is not None
+                self._manager.dispatcher.drop(to_drop)
 
             # Remove dropped items from our copy of the leased messages (they
             # have already been removed from the real one by

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -194,8 +194,8 @@ class Leaser(object):
                 #       without any sort of race condition would require a
                 #       way for ``send_request`` to fail when the consumer
                 #       is inactive.
-                dispatcher = cast("Dispatcher", self._manager.dispatcher)
-                dispatcher.modify_ack_deadline(
+                assert self._manager.dispatcher is not None
+                self._manager.dispatcher.modify_ack_deadline(
                     [requests.ModAckRequest(ack_id, deadline) for ack_id in ack_ids]
                 )
 

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -14,18 +14,26 @@
 
 from __future__ import absolute_import
 
-import collections
 import copy
 import logging
 import random
 import threading
 import time
 import typing
-from typing import Iterable, Sequence, Union
+from typing import cast, Dict, Iterable, Optional, Union
+
+try:
+    from collections.abc import KeysView
+
+    KeysView[None]  # KeysView is only subscriptable in Python 3.9+
+except TypeError:
+    # Deprecated since Python 3.9, thus only use as a fallback in older Python versions
+    from typing import KeysView
 
 from google.cloud.pubsub_v1.subscriber._protocol import requests
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
+    from google.cloud.pubsub_v1.subscriber._protocol.dispatcher import Dispatcher
     from google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager import (
         StreamingPullManager,
     )
@@ -35,14 +43,17 @@ _LOGGER = logging.getLogger(__name__)
 _LEASE_WORKER_NAME = "Thread-LeaseMaintainer"
 
 
-_LeasedMessage = collections.namedtuple(
-    "_LeasedMessage", ["sent_time", "size", "ordering_key"]
-)
+class _LeasedMessage(typing.NamedTuple):
+    sent_time: float
+    """The local time when ACK ID was initially leased in seconds since the epoch."""
+
+    size: int
+    ordering_key: Optional[str]
 
 
 class Leaser(object):
     def __init__(self, manager: "StreamingPullManager"):
-        self._thread = None
+        self._thread: Optional[threading.Thread] = None
         self._manager = manager
 
         # a lock used for start/stop operations, protecting the _thread attribute
@@ -53,11 +64,10 @@ class Leaser(object):
         self._add_remove_lock = threading.Lock()
 
         # Dict of ack_id -> _LeasedMessage
-        self._leased_messages = {}
-        """dict[str, float]: A mapping of ack IDs to the local time when the
-            ack ID was initially leased in seconds since the epoch."""
+        self._leased_messages: Dict[str, _LeasedMessage] = {}
+
         self._bytes = 0
-        """int: The total number of bytes consumed by leased messages."""
+        """The total number of bytes consumed by leased messages."""
 
         self._stop_event = threading.Event()
 
@@ -67,7 +77,7 @@ class Leaser(object):
         return len(self._leased_messages)
 
     @property
-    def ack_ids(self) -> Sequence[str]:
+    def ack_ids(self) -> KeysView[str]:  # pytype: disable=invalid-annotation
         """The ack IDs of all leased messages."""
         return self._leased_messages.keys()
 
@@ -163,7 +173,8 @@ class Leaser(object):
                 _LOGGER.warning(
                     "Dropping %s items because they were leased too long.", len(to_drop)
                 )
-                self._manager.dispatcher.drop(to_drop)
+                dispatcher = cast("Dispatcher", self._manager.dispatcher)
+                dispatcher.drop(to_drop)
 
             # Remove dropped items from our copy of the leased messages (they
             # have already been removed from the real one by
@@ -183,7 +194,8 @@ class Leaser(object):
                 #       without any sort of race condition would require a
                 #       way for ``send_request`` to fail when the consumer
                 #       is inactive.
-                self._manager.dispatcher.modify_ack_deadline(
+                dispatcher = cast("Dispatcher", self._manager.dispatcher)
+                dispatcher.modify_ack_deadline(
                     [requests.ModAckRequest(ack_id, deadline) for ack_id in ack_ids]
                 )
 

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -23,7 +23,7 @@ import typing
 from typing import Any, Callable, Iterable
 import uuid
 
-import grpc
+import grpc  # type: ignore
 
 from google.api_core import bidi
 from google.api_core import exceptions

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import threading
 import typing
-from typing import Any, Callable, Iterable
+from typing import cast, Any, Callable, Iterable, List, Optional, Union
 import uuid
 
 import grpc  # type: ignore
@@ -35,12 +35,11 @@ from google.cloud.pubsub_v1.subscriber._protocol import leaser
 from google.cloud.pubsub_v1.subscriber._protocol import messages_on_hold
 from google.cloud.pubsub_v1.subscriber._protocol import requests
 import google.cloud.pubsub_v1.subscriber.message
-import google.cloud.pubsub_v1.subscriber.scheduler
+from google.cloud.pubsub_v1.subscriber.scheduler import ThreadScheduler
 from google.pubsub_v1 import types as gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1 import subscriber
-    from google.cloud.pubsub_v1.subscriber.scheduler import Scheduler
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -143,7 +142,7 @@ class StreamingPullManager(object):
         client: "subscriber.Client",
         subscription: str,
         flow_control: types.FlowControl = types.FlowControl(),
-        scheduler: "Scheduler" = None,
+        scheduler: ThreadScheduler = None,
         use_legacy_flow_control: bool = False,
         await_callbacks_on_shutdown: bool = False,
     ):
@@ -154,13 +153,15 @@ class StreamingPullManager(object):
         self._await_callbacks_on_shutdown = await_callbacks_on_shutdown
         self._ack_histogram = histogram.Histogram()
         self._last_histogram_size = 0
-        self._ack_deadline = histogram.MIN_ACK_DEADLINE
-        self._rpc = None
-        self._callback = None
+        self._ack_deadline: Union[int, float] = histogram.MIN_ACK_DEADLINE
+        self._rpc: Optional[bidi.ResumableBidiRpc] = None
+        self._callback: Optional[functools.partial] = None
         self._closing = threading.Lock()
         self._closed = False
-        self._close_callbacks = []
-        self._regular_shutdown_thread = None  # Created on intentional shutdown.
+        self._close_callbacks: List[Callable[["StreamingPullManager", Any], Any]] = []
+
+        # A shutdown thread is created on intentional shutdown.
+        self._regular_shutdown_thread: Optional[threading.Thread] = None
 
         # Generate a random client id tied to this object. All streaming pull
         # connections (initial and re-connects) will then use the same client
@@ -169,9 +170,7 @@ class StreamingPullManager(object):
         self._client_id = str(uuid.uuid4())
 
         if scheduler is None:
-            self._scheduler = (
-                google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler()
-            )
+            self._scheduler: Optional[ThreadScheduler] = ThreadScheduler()
         else:
             self._scheduler = scheduler
 
@@ -196,10 +195,10 @@ class StreamingPullManager(object):
         self._ack_deadline_lock = threading.Lock()
 
         # The threads created in ``.open()``.
-        self._dispatcher = None
-        self._leaser = None
-        self._consumer = None
-        self._heartbeater = None
+        self._dispatcher: Optional[dispatcher.Dispatcher] = None
+        self._leaser: Optional[leaser.Leaser] = None
+        self._consumer: Optional[bidi.BackgroundConsumer] = None
+        self._heartbeater: Optional[heartbeater.Heartbeater] = None
 
     @property
     def is_active(self) -> bool:
@@ -216,12 +215,12 @@ class StreamingPullManager(object):
         return self._flow_control
 
     @property
-    def dispatcher(self) -> dispatcher.Dispatcher:
+    def dispatcher(self) -> Optional[dispatcher.Dispatcher]:
         """The dispatcher helper."""
         return self._dispatcher
 
     @property
-    def leaser(self) -> leaser.Leaser:
+    def leaser(self) -> Optional[leaser.Leaser]:
         """The leaser helper."""
         return self._leaser
 
@@ -401,7 +400,9 @@ class StreamingPullManager(object):
 
             self._schedule_message_on_hold(msg)
             released_ack_ids.append(msg.ack_id)
-        self._leaser.start_lease_expiry_timer(released_ack_ids)
+
+        lease_manager = cast(leaser.Leaser, self._leaser)
+        lease_manager.start_lease_expiry_timer(released_ack_ids)
 
     def _schedule_message_on_hold(
         self, msg: "google.cloud.pubsub_v1.subscriber.message.Message"
@@ -430,7 +431,8 @@ class StreamingPullManager(object):
             self._messages_on_hold.size,
             self._on_hold_bytes,
         )
-        self._scheduler.schedule(self._callback, msg)
+        callback = cast(Callable, self._callback)
+        cast(ThreadScheduler, self._scheduler).schedule(callback, msg)
 
     def _send_unary_request(self, request: gapic_types.StreamingPullRequest) -> None:
         """Send a request using a separate unary request instead of over the stream.
@@ -439,7 +441,7 @@ class StreamingPullManager(object):
             request: The stream request to be mapped into unary requests.
         """
         if request.ack_ids:
-            self._client.acknowledge(
+            self._client.acknowledge(  # type: ignore
                 subscription=self._subscription, ack_ids=list(request.ack_ids)
             )
 
@@ -452,7 +454,7 @@ class StreamingPullManager(object):
                 deadline_to_ack_ids[deadline].append(ack_id)
 
             for deadline, ack_ids in deadline_to_ack_ids.items():
-                self._client.modify_ack_deadline(
+                self._client.modify_ack_deadline(  # type: ignore
                     subscription=self._subscription,
                     ack_ids=ack_ids,
                     ack_deadline_seconds=deadline,
@@ -546,7 +548,8 @@ class StreamingPullManager(object):
         # Create references to threads
         # pytype: disable=wrong-arg-types
         # (pytype incorrectly complains about "self" not being the right argument type)
-        self._dispatcher = dispatcher.Dispatcher(self, self._scheduler.queue)
+        scheduler_queue = cast(ThreadScheduler, self._scheduler).queue
+        self._dispatcher = dispatcher.Dispatcher(self, scheduler_queue)
         self._consumer = bidi.BackgroundConsumer(self._rpc, self._on_response)
         self._leaser = leaser.Leaser(self)
         self._heartbeater = heartbeater.Heartbeater(self)
@@ -601,12 +604,12 @@ class StreamingPullManager(object):
             # Stop consuming messages.
             if self.is_active:
                 _LOGGER.debug("Stopping consumer.")
-                self._consumer.stop()
+                cast(bidi.BackgroundConsumer, self._consumer).stop()
             self._consumer = None
 
             # Shutdown all helper threads
             _LOGGER.debug("Stopping scheduler.")
-            dropped_messages = self._scheduler.shutdown(
+            dropped_messages = cast(ThreadScheduler, self._scheduler).shutdown(
                 await_msg_callbacks=self._await_callbacks_on_shutdown
             )
             self._scheduler = None
@@ -621,7 +624,7 @@ class StreamingPullManager(object):
             # for the manager's maybe_resume_consumer() / maybe_pause_consumer(),
             # because the consumer gets shut down first.
             _LOGGER.debug("Stopping leaser.")
-            self._leaser.stop()
+            cast(leaser.Leaser, self._leaser).stop()
 
             total = len(dropped_messages) + len(
                 self._messages_on_hold._messages_on_hold
@@ -634,13 +637,13 @@ class StreamingPullManager(object):
                 msg.nack()
 
             _LOGGER.debug("Stopping dispatcher.")
-            self._dispatcher.stop()
+            cast(dispatcher.Dispatcher, self._dispatcher).stop()
             self._dispatcher = None
             # dispatcher terminated, OK to dispose the leaser reference now
             self._leaser = None
 
             _LOGGER.debug("Stopping heartbeater.")
-            self._heartbeater.stop()
+            cast(heartbeater.Heartbeater, self._heartbeater).stop()
             self._heartbeater = None
 
             self._rpc = None
@@ -730,7 +733,8 @@ class StreamingPullManager(object):
             requests.ModAckRequest(message.ack_id, self.ack_deadline)
             for message in received_messages
         ]
-        self._dispatcher.modify_ack_deadline(items)
+        dispatch_manager = cast(dispatcher.Dispatcher, self._dispatcher)
+        dispatch_manager.modify_ack_deadline(items)
 
         with self._pause_resume_lock:
             for received_message in received_messages:
@@ -738,7 +742,7 @@ class StreamingPullManager(object):
                     received_message.message,
                     received_message.ack_id,
                     received_message.delivery_attempt,
-                    self._scheduler.queue,
+                    cast(ThreadScheduler, self._scheduler).queue,
                 )
                 self._messages_on_hold.put(message)
                 self._on_hold_bytes += message.size
@@ -747,13 +751,14 @@ class StreamingPullManager(object):
                     byte_size=message.size,
                     ordering_key=message.ordering_key,
                 )
-                self.leaser.add([req])
+                lease_manager = cast(leaser.Leaser, self._leaser)
+                lease_manager.add([req])
 
             self._maybe_release_messages()
 
         self.maybe_pause_consumer()
 
-    def _should_recover(self, exception: Exception) -> bool:
+    def _should_recover(self, exception: BaseException) -> bool:
         """Determine if an error on the RPC stream should be recovered.
 
         If the exception is one of the retryable exceptions, this will signal
@@ -775,7 +780,7 @@ class StreamingPullManager(object):
         _LOGGER.info("Observed non-recoverable stream error %s", exception)
         return False
 
-    def _should_terminate(self, exception: Exception) -> bool:
+    def _should_terminate(self, exception: BaseException) -> bool:
         """Determine if an error on the RPC stream should be terminated.
 
         If the exception is one of the terminating exceptions, this will signal

--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -19,8 +19,8 @@ import pkg_resources
 import typing
 from typing import Any, Callable, Optional, Sequence, Union
 
-from google.auth.credentials import AnonymousCredentials
-from google.oauth2 import service_account
+from google.auth.credentials import AnonymousCredentials  # type: ignore
+from google.oauth2 import service_account  # type: ignore
 
 from google.cloud.pubsub_v1 import _gapic
 from google.cloud.pubsub_v1 import types

--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -30,7 +30,9 @@ from google.pubsub_v1.services.subscriber import client as subscriber_client
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1 import subscriber
-    from google.pubsub_v1.services.subscriber.transports.grpc import SubscriberGrpcTransport
+    from google.pubsub_v1.services.subscriber.transports.grpc import (
+        SubscriberGrpcTransport,
+    )
 
 
 try:
@@ -139,7 +141,7 @@ class Client(object):
         subscription: str,
         callback: Callable[["subscriber.message.Message"], Any],
         flow_control: Union[types.FlowControl, Sequence] = (),
-        scheduler: Optional["subscriber.scheduler.Scheduler"] = None,
+        scheduler: Optional["subscriber.scheduler.ThreadScheduler"] = None,
         use_legacy_flow_control: bool = False,
         await_callbacks_on_shutdown: bool = False,
     ) -> futures.StreamingPullFuture:

--- a/google/cloud/pubsub_v1/subscriber/client.py
+++ b/google/cloud/pubsub_v1/subscriber/client.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import os
 import pkg_resources
 import typing
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import cast, Any, Callable, Optional, Sequence, Union
 
 from google.auth.credentials import AnonymousCredentials  # type: ignore
 from google.oauth2 import service_account  # type: ignore
@@ -30,6 +30,7 @@ from google.pubsub_v1.services.subscriber import client as subscriber_client
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1 import subscriber
+    from google.pubsub_v1.services.subscriber.transports.grpc import SubscriberGrpcTransport
 
 
 try:
@@ -263,7 +264,8 @@ class Client(object):
 
         This method is idempotent.
         """
-        self.api._transport.grpc_channel.close()
+        transport = cast("SubscriberGrpcTransport", self.api._transport)
+        transport.grpc_channel.close()
         self._closed = True
 
     def __enter__(self) -> "Client":

--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -83,7 +83,7 @@ class Message(object):
 
     def __init__(  # pytype: disable=module-attr
         self,
-        message: "types.PubsubMessage._meta._pb",
+        message: "types.PubsubMessage._meta._pb",  # type: ignore
         ack_id: str,
         delivery_attempt: int,
         request_queue: "queue.Queue",

--- a/google/cloud/pubsub_v1/subscriber/scheduler.py
+++ b/google/cloud/pubsub_v1/subscriber/scheduler.py
@@ -101,7 +101,7 @@ class ThreadScheduler(Scheduler):
     def __init__(
         self, executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
     ):
-        self._queue = queue.Queue()
+        self._queue: queue.Queue = queue.Queue()
         if executor is None:
             self._executor = _make_default_thread_pool_executor()
         else:

--- a/google/cloud/pubsub_v1/types.py
+++ b/google/cloud/pubsub_v1/types.py
@@ -19,7 +19,7 @@ import enum
 import inspect
 import sys
 import typing
-from typing import Dict, NamedTuple
+from typing import Dict, NamedTuple, Union
 
 import proto  # type: ignore
 
@@ -41,8 +41,11 @@ from google.pubsub_v1.types import pubsub as pubsub_gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from types import ModuleType
-    from google.api_core import retry as retries
     from google.pubsub_v1 import types as gapic_types
+    from google.pubsub_v1.services.publisher.client import OptionalRetry
+
+
+_TimeoutType = Union["gapic_types.TimeoutType", gapic_v1.method._MethodDefault]
 
 
 # Define the default values for batching.
@@ -85,10 +88,10 @@ class LimitExceededBehavior(str, enum.Enum):
 class PublishFlowControl(NamedTuple):
     """The client flow control settings for message publishing."""
 
-    message_limit: int = 10 * BatchSettings.__new__.__defaults__[2]
+    message_limit: int = 10 * BatchSettings.__new__.__defaults__[2]  # type: ignore
     """The maximum number of messages awaiting to be published."""
 
-    byte_limit: int = 10 * BatchSettings.__new__.__defaults__[0]
+    byte_limit: int = 10 * BatchSettings.__new__.__defaults__[0]  # type: ignore
     """The maximum total size of messages awaiting to be published."""
 
     limit_exceeded_behavior: LimitExceededBehavior = LimitExceededBehavior.IGNORE
@@ -111,13 +114,13 @@ class PublisherOptions(NamedTuple):
         "the publisher client does not do any throttling."
     )
 
-    retry: "retries.Retry" = gapic_v1.method.DEFAULT  # use api_core default
+    retry: "OptionalRetry" = gapic_v1.method.DEFAULT  # use api_core default
     (
         "Retry settings for message publishing by the client. This should be "
         "an instance of :class:`google.api_core.retry.Retry`."
     )
 
-    timeout: "gapic_types.TimeoutType" = gapic_v1.method.DEFAULT  # use api_core default
+    timeout: _TimeoutType = gapic_v1.method.DEFAULT  # use api_core default
     (
         "Timeout settings for message publishing by the client. It should be "
         "compatible with :class:`~.pubsub_v1.types.TimeoutType`."

--- a/google/cloud/pubsub_v1/types.py
+++ b/google/cloud/pubsub_v1/types.py
@@ -44,8 +44,15 @@ if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.pubsub_v1 import types as gapic_types
     from google.pubsub_v1.services.publisher.client import OptionalRetry
 
-
-_TimeoutType = Union["gapic_types.TimeoutType", gapic_v1.method._MethodDefault]
+    # TODO: Eventually implement OptionalTimeout in the GAPIC code generator and import
+    # it from the generated code. It's the same solution that is used for OptionalRetry.
+    # https://github.com/googleapis/gapic-generator-python/pull/1032/files
+    # https://github.com/googleapis/gapic-generator-python/pull/1065/files
+    if hasattr(gapic_v1.method, "_MethodDefault"):
+        # _MethodDefault was only added in google-api-core==2.2.2
+        OptionalTimeout = Union[gapic_types.TimeoutType, gapic_v1.method._MethodDefault]
+    else:
+        OptionalTimeout = Union[gapic_types.TimeoutType, object]  # type: ignore
 
 
 # Define the default values for batching.
@@ -120,11 +127,13 @@ class PublisherOptions(NamedTuple):
         "an instance of :class:`google.api_core.retry.Retry`."
     )
 
-    timeout: _TimeoutType = gapic_v1.method.DEFAULT  # use api_core default
+    # pytype: disable=invalid-annotation
+    timeout: "OptionalTimeout" = gapic_v1.method.DEFAULT  # use api_core default
     (
         "Timeout settings for message publishing by the client. It should be "
         "compatible with :class:`~.pubsub_v1.types.TimeoutType`."
     )
+    # pytype: enable=invalid-annotation
 
 
 # Define the type class and default values for flow control settings.

--- a/google/cloud/pubsub_v1/types.py
+++ b/google/cloud/pubsub_v1/types.py
@@ -21,13 +21,13 @@ import sys
 import typing
 from typing import Dict, NamedTuple
 
-import proto
+import proto  # type: ignore
 
-from google.api import http_pb2
+from google.api import http_pb2  # type: ignore
 from google.api_core import gapic_v1
-from google.iam.v1 import iam_policy_pb2
+from google.iam.v1 import iam_policy_pb2  # type: ignore
 from google.iam.v1 import policy_pb2
-from google.iam.v1.logging import audit_data_pb2
+from google.iam.v1.logging import audit_data_pb2  # type: ignore
 from google.protobuf import descriptor_pb2
 from google.protobuf import duration_pb2
 from google.protobuf import empty_pb2

--- a/google/cloud/py.typed
+++ b/google/cloud/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# The google-cloud-pubsub package uses inline types.

--- a/google/cloud/py.typed
+++ b/google/cloud/py.typed
@@ -1,2 +1,0 @@
-# Marker file for PEP 561.
-# The google-cloud-pubsub package uses inline types.

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,7 @@ import nox
 BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
+MYPY_VERSION = "mypy==0.910"
 PYTYPE_VERSION = "pytype==2021.4.9"
 
 
@@ -44,6 +45,7 @@ nox.options.sessions = [
     "lint",
     "lint_setup_py",
     "blacken",
+    "mypy",
     "pytype",
     "docs",
 ]
@@ -53,9 +55,23 @@ nox.options.error_on_missing_interpreters = True
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
+def mypy(session):
+    """Run type checks with mypy."""
+    session.install("-e", ".")
+    session.install(MYPY_VERSION)
+
+    # Just install the type info directly, since "mypy --install-types" might require
+    # an additional pass.
+    session.install("types-protobuf", "types-setuptools")
+
+    # Check the hand-written layer.
+    session.run("mypy", "google/cloud")
+
+
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def pytype(session):
     """Run type checks."""
-    session.install("-e", ".[all]")
+    session.install("-e", ".")
     session.install(PYTYPE_VERSION)
     session.run("pytype")
 

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -401,6 +401,7 @@ def test__maybe_release_messages_negative_on_hold_bytes_warning(caplog):
     manager = make_manager(
         flow_control=types.FlowControl(max_messages=10, max_bytes=1000)
     )
+    manager._callback = lambda msg: msg  # pragma: NO COVER
 
     msg = mock.create_autospec(message.Message, instance=True, ack_id="ack", size=17)
     manager._messages_on_hold.put(msg)


### PR DESCRIPTION
Towards googleapis/google-cloud-python#15652.

This is a draft PR. The new noxfile check, mypy, passes locally, but there are still a few things to consider:
 - [x] The generated code is omitted from type checks, because `mypy` reports several errors for it
   (will be done separately, since it's currently blocked by https://github.com/googleapis/gapic-generator-python/issues/1092 )
 - [x] ~~The PR adds `py.typed` marker file, but we might want to postpone this addition until the generated code is error-free.~~   Marker file removed for the time being.
 - [x] Some type aliases such as `_TimeoutType` are defined in multiple places. We should probably extract the definition to a single central place within the library.

**PR checklist:**
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
