### PR TITLE
feat: exactly-once delivery support

### DIFF
--- a/google/cloud/pubsub_v1/proto/pubsub.proto
+++ b/google/cloud/pubsub_v1/proto/pubsub.proto
@@ -1164,6 +1164,7 @@ message StreamingPullRequest {
 message StreamingPullResponse {
   // Subscription properties sent as part of the response.
   message SubscriptionProperties {
+    bool exactly_once_delivery_enabled = 1;
     // True iff message ordering is enabled for this subscription.
     bool message_ordering_enabled = 2;
   }

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -70,11 +70,11 @@ IDs at a time.
 
 _MIN_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS = 1
 """The time to wait for the first retry of failed acks and modacks when exactly-once
-is enabled."""
+delivery is enabled."""
 
 _MAX_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS = 10 * 60
 """The maximum amount of time in seconds to retry failed acks and modacks when
-exactly-once is enabled."""
+exactly-once delivery is enabled."""
 
 
 class Dispatcher(object):

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -201,7 +201,7 @@ class Dispatcher(object):
                 maximum=_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
             )
             while requests_to_retry:
-                time_to_wait = retry_delay_gen()
+                time_to_wait = next(retry_delay_gen)
                 _LOGGER.debug(
                     "Retrying {len(requests_to_retry)} ack(s) after delay of "
                     + str(time_to_wait)
@@ -288,7 +288,7 @@ class Dispatcher(object):
                 maximum=_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
             )
             while requests_to_retry:
-                time_to_wait = retry_delay_gen()
+                time_to_wait = next(retry_delay_gen)
                 _LOGGER.debug(
                     "Retrying {len(requests_to_retry)} modack(s) after delay of "
                     + str(time_to_wait)
@@ -299,7 +299,7 @@ class Dispatcher(object):
                 future_reqs_dict = {
                     req.ack_id: req for req in requests_to_retry if req.future
                 }
-                requests_to_retry = self._manager.send_unary_modack(
+                requests_completed, requests_to_retry = self._manager.send_unary_modack(
                     modify_deadline_ack_ids=[req.ack_id for req in requests_to_retry],
                     modify_deadline_seconds=[req.seconds for req in requests_to_retry],
                     future_reqs_dict=future_reqs_dict,

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -22,6 +22,7 @@ import threading
 import typing
 from typing import List, Optional, Sequence, Union
 import warnings
+from google.api_core.retry import exponential_sleep_generator
 
 from google.cloud.pubsub_v1.subscriber._protocol import helper_threads
 from google.cloud.pubsub_v1.subscriber._protocol import requests
@@ -66,6 +67,13 @@ Accounting for some overhead, we should thus only send a maximum of 2500 ACK
 IDs at a time.
 """
 
+_MIN_ACK_MODACK_RETRY_DURATION_SECS = 1
+"""The time to wait for the first retry of failed acks and modacks when exactly-once
+is enabled."""
+
+_MAX_ACK_MODACK_RETRY_DURATION_SECS = 20 * 60
+"""The maximum amount of time in seconds to retry failed acks and modacks when
+exactly-once is enabled."""
 
 class Dispatcher(object):
     def __init__(self, manager: "StreamingPullManager", queue: "queue.Queue"):
@@ -168,17 +176,35 @@ class Dispatcher(object):
 
         # We must potentially split the request into multiple smaller requests
         # to avoid the server-side max request size limit.
-        ack_ids = (item.ack_id for item in items)
+        items_gen = iter(items)
+        ack_ids_gen = (item.ack_id for item in items)
         total_chunks = int(math.ceil(len(items) / _ACK_IDS_BATCH_SIZE))
 
         for _ in range(total_chunks):
-            request = gapic_types.StreamingPullRequest(
-                ack_ids=itertools.islice(ack_ids, _ACK_IDS_BATCH_SIZE)
-            )
-            self._manager.send(request)
+            future_reqs_dict = {req.ack_id: req for req in itertools.islice(items_gen, _ACK_IDS_BATCH_SIZE) if req.future}
+            requests_completed, requests_to_retry =  self._manager.send_unary_ack(
+                ack_ids=list(itertools.islice(ack_ids_gen, _ACK_IDS_BATCH_SIZE)),
+                future_reqs_dict=future_reqs_dict)
 
-        # Remove the message from lease management.
-        self.drop(items)
+            # Remove the completed messages from lease management.
+            self.drop(requests_completed)
+
+            # retry acks
+            retry_delay_gen = exponential_sleep_generator(initial=_MIN_ACK_MODACK_RETRY_DURATION_SECS,
+                                                          maximum=_MAX_ACK_MODACK_RETRY_DURATION_SECS)
+            while requests_to_retry:
+                time_to_wait = retry_delay_gen()
+                _LOGGER.debug("Retrying {len(requests_to_retry)} ack(s) after delay of " +
+                              str(time_to_wait) + " seconds")
+                time.sleep(time_to_wait)
+
+                future_reqs_dict = {req.ack_id: req for req in requests_to_retry if req.future}
+                requests_completed, requests_to_retry = self._manager.send_unary_ack(
+                    ack_ids=[req.ack_id for req in requests_to_retry],
+                    future_reqs_dict=future_reqs_dict)
+                assert len(requests_to_retry) <= _ACK_IDS_BATCH_SIZE, "Too many requests to be retried."
+                # Remove the completed messages from lease management.
+                self.drop(requests_completed)
 
     def drop(
         self,
@@ -215,16 +241,35 @@ class Dispatcher(object):
         """
         # We must potentially split the request into multiple smaller requests
         # to avoid the server-side max request size limit.
-        ack_ids = (item.ack_id for item in items)
-        seconds = (item.seconds for item in items)
+        items_gen = iter(items)
+        ack_ids_gen = (item.ack_id for item in items)
+        deadline_seconds_gen = (item.seconds for item in items)
         total_chunks = int(math.ceil(len(items) / _ACK_IDS_BATCH_SIZE))
 
         for _ in range(total_chunks):
-            request = gapic_types.StreamingPullRequest(
-                modify_deadline_ack_ids=itertools.islice(ack_ids, _ACK_IDS_BATCH_SIZE),
-                modify_deadline_seconds=itertools.islice(seconds, _ACK_IDS_BATCH_SIZE),
-            )
-            self._manager.send(request)
+            future_reqs_dict = {req.ack_id: req for req in itertools.islice(items_gen, _ACK_IDS_BATCH_SIZE) if req.future}
+            # no further work needs to be done for `requests_to_retry`
+            requests_completed, requests_to_retry = self._manager.send_unary_modack(
+                modify_deadline_ack_ids=list(itertools.islice(ack_ids_gen, _ACK_IDS_BATCH_SIZE)),
+                modify_deadline_seconds=list(itertools.islice(deadline_seconds_gen, _ACK_IDS_BATCH_SIZE)),
+                future_reqs_dict=future_reqs_dict)
+            assert len(requests_to_retry) <= _ACK_IDS_BATCH_SIZE, "Too many requests to be retried."
+
+            # retry modacks
+            retry_delay_gen = exponential_sleep_generator(initial=_MIN_ACK_MODACK_RETRY_DURATION_SECS,
+                                                          maximum=_MAX_ACK_MODACK_RETRY_DURATION_SECS)
+            while requests_to_retry:
+                time_to_wait = retry_delay_gen()
+                _LOGGER.debug("Retrying {len(requests_to_retry)} modack(s) after delay of " +
+                              str(time_to_wait) + " seconds")
+                time.sleep(time_to_wait)
+
+                print(requests_to_retry)
+                future_reqs_dict = {req.ack_id: req for req in requests_to_retry if req.future}
+                requests_to_retry = self._manager.send_unary_modack(
+                    modify_deadline_ack_ids=[req.ack_id for req in requests_to_retry],
+                    modify_deadline_seconds=[req.seconds for req in requests_to_retry],
+                    future_reqs_dict=future_reqs_dict)
 
     def nack(self, items: Sequence[requests.NackRequest]) -> None:
         """Explicitly deny receipt of messages.
@@ -233,6 +278,6 @@ class Dispatcher(object):
             items: The items to deny.
         """
         self.modify_ack_deadline(
-            [requests.ModAckRequest(ack_id=item.ack_id, seconds=0) for item in items]
+            [requests.ModAckRequest(ack_id=item.ack_id, seconds=0, future=item.future) for item in items]
         )
-        self.drop([requests.DropRequest(*item) for item in items])
+        self.drop([requests.DropRequest(ack_id=item.ack_id, byte_size=item.byte_size, ordering_key=item.ordering_key) for item in items])

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -68,11 +68,11 @@ Accounting for some overhead, we should thus only send a maximum of 2500 ACK
 IDs at a time.
 """
 
-_MIN_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS = 1
+_MIN_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS = 1
 """The time to wait for the first retry of failed acks and modacks when exactly-once
 is enabled."""
 
-_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS = 10 * 60
+_MAX_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS = 10 * 60
 """The maximum amount of time in seconds to retry failed acks and modacks when
 exactly-once is enabled."""
 
@@ -217,8 +217,8 @@ class Dispatcher(object):
 
     def _retry_acks(self, requests_to_retry):
         retry_delay_gen = exponential_sleep_generator(
-            initial=_MIN_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
-            maximum=_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
+            initial=_MIN_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS,
+            maximum=_MAX_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS,
         )
         while requests_to_retry:
             time_to_wait = next(retry_delay_gen)
@@ -312,8 +312,8 @@ class Dispatcher(object):
 
     def _retry_modacks(self, requests_to_retry):
         retry_delay_gen = exponential_sleep_generator(
-            initial=_MIN_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
-            maximum=_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
+            initial=_MIN_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS,
+            maximum=_MAX_EXACTLY_ONCE_DELIVERY_ACK_MODACK_RETRY_DURATION_SECS,
         )
         while requests_to_retry:
             time_to_wait = next(retry_delay_gen)

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -183,13 +183,13 @@ class Dispatcher(object):
         total_chunks = int(math.ceil(len(items) / _ACK_IDS_BATCH_SIZE))
 
         for _ in range(total_chunks):
-            future_reqs_dict = {
+            ack_reqs_dict = {
                 req.ack_id: req
                 for req in itertools.islice(items_gen, _ACK_IDS_BATCH_SIZE)
             }
             requests_completed, requests_to_retry = self._manager.send_unary_ack(
                 ack_ids=list(itertools.islice(ack_ids_gen, _ACK_IDS_BATCH_SIZE)),
-                future_reqs_dict=future_reqs_dict,
+                ack_reqs_dict=ack_reqs_dict,
             )
 
             # Remove the completed messages from lease management.
@@ -228,10 +228,10 @@ class Dispatcher(object):
             )
             time.sleep(time_to_wait)
 
-            future_reqs_dict = {req.ack_id: req for req in requests_to_retry}
+            ack_reqs_dict = {req.ack_id: req for req in requests_to_retry}
             requests_completed, requests_to_retry = self._manager.send_unary_ack(
                 ack_ids=[req.ack_id for req in requests_to_retry],
-                future_reqs_dict=future_reqs_dict,
+                ack_reqs_dict=ack_reqs_dict,
             )
             assert (
                 len(requests_to_retry) <= _ACK_IDS_BATCH_SIZE
@@ -280,7 +280,7 @@ class Dispatcher(object):
         total_chunks = int(math.ceil(len(items) / _ACK_IDS_BATCH_SIZE))
 
         for _ in range(total_chunks):
-            future_reqs_dict = {
+            ack_reqs_dict = {
                 req.ack_id: req
                 for req in itertools.islice(items_gen, _ACK_IDS_BATCH_SIZE)
             }
@@ -292,7 +292,7 @@ class Dispatcher(object):
                 modify_deadline_seconds=list(
                     itertools.islice(deadline_seconds_gen, _ACK_IDS_BATCH_SIZE)
                 ),
-                future_reqs_dict=future_reqs_dict,
+                ack_reqs_dict=ack_reqs_dict,
             )
             assert (
                 len(requests_to_retry) <= _ACK_IDS_BATCH_SIZE
@@ -320,11 +320,11 @@ class Dispatcher(object):
             )
             time.sleep(time_to_wait)
 
-            future_reqs_dict = {req.ack_id: req for req in requests_to_retry}
+            ack_reqs_dict = {req.ack_id: req for req in requests_to_retry}
             requests_completed, requests_to_retry = self._manager.send_unary_modack(
                 modify_deadline_ack_ids=[req.ack_id for req in requests_to_retry],
                 modify_deadline_seconds=[req.seconds for req in requests_to_retry],
-                future_reqs_dict=future_reqs_dict,
+                ack_reqs_dict=ack_reqs_dict,
             )
 
     def nack(self, items: Sequence[requests.NackRequest]) -> None:

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -67,11 +67,11 @@ Accounting for some overhead, we should thus only send a maximum of 2500 ACK
 IDs at a time.
 """
 
-_MIN_ACK_MODACK_RETRY_DURATION_SECS = 1
+_MIN_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS = 1
 """The time to wait for the first retry of failed acks and modacks when exactly-once
 is enabled."""
 
-_MAX_ACK_MODACK_RETRY_DURATION_SECS = 20 * 60
+_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS = 10 * 60
 """The maximum amount of time in seconds to retry failed acks and modacks when
 exactly-once is enabled."""
 
@@ -190,8 +190,8 @@ class Dispatcher(object):
             self.drop(requests_completed)
 
             # retry acks
-            retry_delay_gen = exponential_sleep_generator(initial=_MIN_ACK_MODACK_RETRY_DURATION_SECS,
-                                                          maximum=_MAX_ACK_MODACK_RETRY_DURATION_SECS)
+            retry_delay_gen = exponential_sleep_generator(initial=_MIN_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
+                                                          maximum=_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS)
             while requests_to_retry:
                 time_to_wait = retry_delay_gen()
                 _LOGGER.debug("Retrying {len(requests_to_retry)} ack(s) after delay of " +
@@ -256,8 +256,8 @@ class Dispatcher(object):
             assert len(requests_to_retry) <= _ACK_IDS_BATCH_SIZE, "Too many requests to be retried."
 
             # retry modacks
-            retry_delay_gen = exponential_sleep_generator(initial=_MIN_ACK_MODACK_RETRY_DURATION_SECS,
-                                                          maximum=_MAX_ACK_MODACK_RETRY_DURATION_SECS)
+            retry_delay_gen = exponential_sleep_generator(initial=_MIN_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS,
+                                                          maximum=_MAX_EXACTLY_ONCE_ACK_MODACK_RETRY_DURATION_SECS)
             while requests_to_retry:
                 time_to_wait = retry_delay_gen()
                 _LOGGER.debug("Retrying {len(requests_to_retry)} modack(s) after delay of " +

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -186,7 +186,6 @@ class Dispatcher(object):
             future_reqs_dict = {
                 req.ack_id: req
                 for req in itertools.islice(items_gen, _ACK_IDS_BATCH_SIZE)
-                if req.future
             }
             requests_completed, requests_to_retry = self._manager.send_unary_ack(
                 ack_ids=list(itertools.islice(ack_ids_gen, _ACK_IDS_BATCH_SIZE)),
@@ -229,9 +228,7 @@ class Dispatcher(object):
             )
             time.sleep(time_to_wait)
 
-            future_reqs_dict = {
-                req.ack_id: req for req in requests_to_retry if req.future
-            }
+            future_reqs_dict = {req.ack_id: req for req in requests_to_retry}
             requests_completed, requests_to_retry = self._manager.send_unary_ack(
                 ack_ids=[req.ack_id for req in requests_to_retry],
                 future_reqs_dict=future_reqs_dict,
@@ -286,7 +283,6 @@ class Dispatcher(object):
             future_reqs_dict = {
                 req.ack_id: req
                 for req in itertools.islice(items_gen, _ACK_IDS_BATCH_SIZE)
-                if req.future
             }
             # no further work needs to be done for `requests_to_retry`
             requests_completed, requests_to_retry = self._manager.send_unary_modack(
@@ -324,9 +320,7 @@ class Dispatcher(object):
             )
             time.sleep(time_to_wait)
 
-            future_reqs_dict = {
-                req.ack_id: req for req in requests_to_retry if req.future
-            }
+            future_reqs_dict = {req.ack_id: req for req in requests_to_retry}
             requests_completed, requests_to_retry = self._manager.send_unary_modack(
                 modify_deadline_ack_ids=[req.ack_id for req in requests_to_retry],
                 modify_deadline_seconds=[req.seconds for req in requests_to_retry],

--- a/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -18,6 +18,7 @@ from __future__ import division
 import itertools
 import logging
 import math
+import time
 import threading
 import typing
 from typing import List, Optional, Sequence, Union
@@ -26,7 +27,6 @@ from google.api_core.retry import exponential_sleep_generator
 
 from google.cloud.pubsub_v1.subscriber._protocol import helper_threads
 from google.cloud.pubsub_v1.subscriber._protocol import requests
-from google.pubsub_v1 import types as gapic_types
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     import queue
@@ -296,7 +296,6 @@ class Dispatcher(object):
                 )
                 time.sleep(time_to_wait)
 
-                print(requests_to_retry)
                 future_reqs_dict = {
                     req.ack_id: req for req in requests_to_retry if req.future
                 }

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -195,7 +195,10 @@ class Leaser(object):
                 #       is inactive.
                 assert self._manager.dispatcher is not None
                 self._manager.dispatcher.modify_ack_deadline(
-                    [requests.ModAckRequest(ack_id, deadline, None) for ack_id in ack_ids]
+                    [
+                        requests.ModAckRequest(ack_id, deadline, None)
+                        for ack_id in ack_ids
+                    ]
                 )
 
             # Now wait an appropriate period of time and do this again.

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -195,7 +195,7 @@ class Leaser(object):
                 #       is inactive.
                 assert self._manager.dispatcher is not None
                 self._manager.dispatcher.modify_ack_deadline(
-                    [requests.ModAckRequest(ack_id, deadline) for ack_id in ack_ids]
+                    [requests.ModAckRequest(ack_id, deadline, None) for ack_id in ack_ids]
                 )
 
             # Now wait an appropriate period of time and do this again.

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -194,12 +194,6 @@ class Leaser(object):
                 #       way for ``send_request`` to fail when the consumer
                 #       is inactive.
                 assert self._manager.dispatcher is not None
-                self._manager.dispatcher.modify_ack_deadline(
-                    [
-                        requests.ModAckRequest(ack_id, deadline, None)
-                        for ack_id in ack_ids
-                    ]
-                )
                 ack_id_gen = (ack_id for ack_id in ack_ids)
                 self._manager._send_lease_modacks(ack_id_gen, ack_deadline)
 

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -181,7 +181,7 @@ class Leaser(object):
             for item in to_drop:
                 leased_messages.pop(item.ack_id)
 
-            # Create a streaming pull request.
+            # Create a modack request.
             # We do not actually call `modify_ack_deadline` over and over
             # because it is more efficient to make a single request.
             ack_ids = leased_messages.keys()
@@ -200,6 +200,8 @@ class Leaser(object):
                         for ack_id in ack_ids
                     ]
                 )
+                ack_id_gen = (ack_id for ack_id in ack_ids)
+                self._manager._send_lease_modacks(ack_id_gen, ack_deadline)
 
             # Now wait an appropriate period of time and do this again.
             #

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -195,7 +195,7 @@ class Leaser(object):
                 #       is inactive.
                 assert self._manager.dispatcher is not None
                 ack_id_gen = (ack_id for ack_id in ack_ids)
-                self._manager._send_lease_modacks(ack_id_gen, ack_deadline)
+                self._manager._send_lease_modacks(ack_id_gen, deadline)
 
             # Now wait an appropriate period of time and do this again.
             #

--- a/google/cloud/pubsub_v1/subscriber/_protocol/requests.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/requests.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import typing
 from typing import NamedTuple, Optional
 
+if typing.TYPE_CHECKING:  # pragma: NO COVER
+    from google.cloud.pubsub_v1.subscriber import futures
 
 # Namedtuples for management requests. Used by the Message class to communicate
 # items of work back to the policy.
@@ -22,6 +25,7 @@ class AckRequest(NamedTuple):
     byte_size: int
     time_to_ack: float
     ordering_key: Optional[str]
+    future: Optional["pubsub_v1.subscriber.futures.Future"]
 
 
 class DropRequest(NamedTuple):
@@ -39,9 +43,11 @@ class LeaseRequest(NamedTuple):
 class ModAckRequest(NamedTuple):
     ack_id: str
     seconds: float
+    future: Optional["pubsub_v1.subscriber.futures.Future"]
 
 
 class NackRequest(NamedTuple):
     ack_id: str
     byte_size: int
     ordering_key: Optional[str]
+    future: Optional["pubsub_v1.subscriber.futures.Future"]

--- a/google/cloud/pubsub_v1/subscriber/_protocol/requests.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/requests.py
@@ -18,6 +18,7 @@ from typing import NamedTuple, Optional
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1.subscriber import futures
 
+
 # Namedtuples for management requests. Used by the Message class to communicate
 # items of work back to the policy.
 class AckRequest(NamedTuple):
@@ -25,7 +26,7 @@ class AckRequest(NamedTuple):
     byte_size: int
     time_to_ack: float
     ordering_key: Optional[str]
-    future: Optional["pubsub_v1.subscriber.futures.Future"]
+    future: Optional["futures.Future"]
 
 
 class DropRequest(NamedTuple):
@@ -43,11 +44,11 @@ class LeaseRequest(NamedTuple):
 class ModAckRequest(NamedTuple):
     ack_id: str
     seconds: float
-    future: Optional["pubsub_v1.subscriber.futures.Future"]
+    future: Optional["futures.Future"]
 
 
 class NackRequest(NamedTuple):
     ack_id: str
     byte_size: int
     ordering_key: Optional[str]
-    future: Optional["pubsub_v1.subscriber.futures.Future"]
+    future: Optional["futures.Future"]

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -154,11 +154,11 @@ def _process_requests(
     ack_reqs_dict: "containers.ScalarMap",
     errors_dict: Optional["containers.ScalarMap"],
 ):
-    """Process futures by referring to errors_dict.
+    """Process requests by referring to error_status and errors_dict.
 
-    The errors returned by the server in `errors_dict` are used to complete
-    the request futures in `ack_reqs_dict` (with a success or exception) or
-    to return requests for further retries.
+    The errors returned by the server in as `error_status` or in `errors_dict`
+    are used to complete the request futures in `ack_reqs_dict` (with a success
+    or exception) or to return requests for further retries.
     """
     requests_completed = []
     requests_to_retry = []
@@ -564,6 +564,7 @@ class StreamingPullManager(object):
         error is re-raised.
         """
         assert ack_ids
+        assert len(ack_ids) == len(ack_reqs_dict)
 
         error_status = None
         ack_errors_dict = None

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -886,7 +886,7 @@ class StreamingPullManager(object):
             for req in items:
                 try:
                     req.future.result()
-                except pubsub_1.subscriber.exceptions.AcknowledgeError as e:
+                except AcknowledgeError as e:
                     _LOGGER.warning(
                         f"AcknowledgeError when modacking a message immediately after receiving it.",
                         exc_info=False,

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -199,7 +199,7 @@ def _process_futures(
         else:
             future = future_reqs_dict[ack_id].future
             # success
-            future.set_result(ack_id)
+            future.set_result(AcknowledgeErrorCode.SUCCESS)
             requests_completed.append(future_reqs_dict[ack_id])
 
     return requests_completed, requests_to_retry

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -385,7 +385,8 @@ class StreamingPullManager(object):
                 )
                 self._ack_deadline = max(self._ack_deadline, flow_control_setting)
             elif self._exactly_once_enabled:
-                # Higher minimum ack_deadline for exactly_once subscriptions.
+                # Higher minimum ack_deadline for subscriptions with
+                # exactly-once delivery enabled.
                 self._ack_deadline = max(
                     self._ack_deadline, _MIN_ACK_DEADLINE_SECS_WHEN_EXACTLY_ONCE_ENABLED
                 )
@@ -652,7 +653,7 @@ class StreamingPullManager(object):
         """Sends a heartbeat request over the streaming pull RPC.
 
         The request is empty by default, but may contain the current ack_deadline
-        if the exactly_once flag has changed.
+        if the self._exactly_once_enabled flag has changed.
 
         Returns:
             If a heartbeat request has actually been sent.

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -141,12 +141,11 @@ def _get_ack_errors(
         _LOGGER.debug("Unable to get status of errored RPC.")
         return None
     for detail in status.details:
-        if detail.Is(ErrorInfo.DESCRIPTOR):
-            info = ErrorInfo()
-            if not detail.Unpack(info):
-                _LOGGER.debug("Unable to unpack ErrorInfo.")
-                return None
-            return info.metadata
+        info = ErrorInfo()
+        if not (detail.Is(ErrorInfo.DESCRIPTOR) and detail.Unpack(info)):
+            _LOGGER.debug("Unable to unpack ErrorInfo.")
+            return None
+        return info.metadata
     return None
 
 

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -870,7 +870,7 @@ class StreamingPullManager(object):
         return request
 
     def _send_lease_modacks(self, ack_ids: Sequence[str], ack_deadline: int):
-        exactly_once_enabled = None
+        exactly_once_enabled = False
         with self._exactly_once_enabled_lock:
             exactly_once_enabled = self._exactly_once_enabled
         if exactly_once_enabled:
@@ -893,8 +893,8 @@ class StreamingPullManager(object):
                     )
         else:
             items = [
-                requests.ModAckRequest(message.ack_id, self.ack_deadline, None)
-                for message in received_messages
+                requests.ModAckRequest(ack_id, self.ack_deadline, None)
+                for ack_id in ack_ids
             ]
             assert self._dispatcher is not None
             self._dispatcher.modify_ack_deadline(items)

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -114,7 +114,7 @@ def _wrap_callback_errors(
 
 
 def _get_ack_errors(
-    exc: exceptions.GoogleAPICallError
+    exc: exceptions.GoogleAPICallError,
 ) -> Optional["containers.ScalarMap"]:
     if not exc.response:
         _LOGGER.debug("No response obj in errored RPC call.")

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -898,6 +898,11 @@ class StreamingPullManager(object):
             assert self._dispatcher is not None
             self._dispatcher.modify_ack_deadline(items)
 
+    def _exactly_once_delivery_enabled(self) -> bool:
+        """Whether exactly-once delivery is enabled for the subscription."""
+        with self._exactly_once_enabled_lock:
+            return self._exactly_once_enabled
+
     def _on_response(self, response: gapic_types.StreamingPullResponse) -> None:
         """Process all received Pub/Sub messages.
 
@@ -957,6 +962,7 @@ class StreamingPullManager(object):
                     received_message.ack_id,
                     received_message.delivery_attempt,
                     self._scheduler.queue,
+                    self._exactly_once_delivery_enabled,
                 )
                 self._messages_on_hold.put(message)
                 self._on_hold_bytes += message.size

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -887,7 +887,7 @@ class StreamingPullManager(object):
                     req.future.result()
                 except AcknowledgeError:
                     _LOGGER.warning(
-                        "AcknowledgeError when modacking a message immediately after receiving it.",
+                        "AcknowledgeError when lease-modacking a message.",
                         exc_info=True,
                     )
         else:

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -48,7 +48,6 @@ from google.rpc import code_pb2
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1 import subscriber
-    from google.cloud.pubsub_v1.subscriber.scheduler import Scheduler
     from google.protobuf.internal import containers
     from google.rpc import status_pb2
 
@@ -886,10 +885,10 @@ class StreamingPullManager(object):
             for req in items:
                 try:
                     req.future.result()
-                except AcknowledgeError as e:
+                except AcknowledgeError:
                     _LOGGER.warning(
-                        f"AcknowledgeError when modacking a message immediately after receiving it.",
-                        exc_info=False,
+                        "AcknowledgeError when modacking a message immediately after receiving it.",
+                        exc_info=True,
                     )
         else:
             items = [

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -188,10 +188,12 @@ def _process_futures(
             future = future_reqs_dict[ack_id].future
             future.set_exception(exc)
             requests_completed.append(future_reqs_dict[ack_id])
-        else:
+        elif future_reqs_dict[ack_id].future:
             future = future_reqs_dict[ack_id].future
             # success
             future.set_result(AcknowledgeStatus.SUCCESS)
+            requests_completed.append(future_reqs_dict[ack_id])
+        else:
             requests_completed.append(future_reqs_dict[ack_id])
 
     return requests_completed, requests_to_retry

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -34,7 +34,7 @@ from google.cloud.pubsub_v1.subscriber._protocol import histogram
 from google.cloud.pubsub_v1.subscriber._protocol import leaser
 from google.cloud.pubsub_v1.subscriber._protocol import messages_on_hold
 from google.cloud.pubsub_v1.subscriber._protocol import requests
-from google.cloud.pubsub_v1.subscriber.exceptions import AcknowledgeError, AcknowledgeErrorCode
+from google.cloud.pubsub_v1.subscriber.exceptions import AcknowledgeError, AcknowledgeStatus
 import google.cloud.pubsub_v1.subscriber.message
 from google.cloud.pubsub_v1.subscriber.scheduler import ThreadScheduler
 from google.pubsub_v1 import types as gapic_types
@@ -168,11 +168,11 @@ def _process_futures(
             else:
                 if exactly_once_error == "PERMANENT_FAILURE_INVALID_ACK_ID":
                     exc = AcknowledgeError(
-                        AcknowledgeErrorCode.INVALID_ACK_ID, info = None
+                        AcknowledgeStatus.INVALID_ACK_ID, info = None
                     )
                 else:
                     exc = AcknowledgeError(
-                        AcknowledgeErrorCode.OTHER, exactly_once_error
+                        AcknowledgeStatus.OTHER, exactly_once_error
                     )
 
                 future = future_reqs_dict[ack_id].future
@@ -183,15 +183,15 @@ def _process_futures(
             # retried at the lower, GRPC level.
             if error_status.code == code_pb2.PERMISSION_DENIED:
                 exc = AcknowledgeError(
-                    AcknowledgeErrorCode.PERMISSION_DENIED, info = None
+                    AcknowledgeStatus.PERMISSION_DENIED, info = None
                 )
             elif error_status.code == code_pb2.FAILED_PRECONDITION:
                 exc = AcknowledgeError(
-                    AcknowledgeErrorCode.FAILED_PRECONDITION, info = None
+                    AcknowledgeStatus.FAILED_PRECONDITION, info = None
                 )
             else:
                 exc = AcknowledgeError(
-                    AcknowledgeErrorCode.OTHER, str(error_status)
+                    AcknowledgeStatus.OTHER, str(error_status)
                 )
             future = future_reqs_dict[ack_id].future
             future.set_exception(exc)
@@ -199,7 +199,7 @@ def _process_futures(
         else:
             future = future_reqs_dict[ack_id].future
             # success
-            future.set_result(AcknowledgeErrorCode.SUCCESS)
+            future.set_result(AcknowledgeStatus.SUCCESS)
             requests_completed.append(future_reqs_dict[ack_id])
 
     return requests_completed, requests_to_retry

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import threading
 import typing
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 import uuid
 
 import grpc  # type: ignore
@@ -42,9 +42,9 @@ import google.cloud.pubsub_v1.subscriber.message
 from google.cloud.pubsub_v1.subscriber import futures
 from google.cloud.pubsub_v1.subscriber.scheduler import ThreadScheduler
 from google.pubsub_v1 import types as gapic_types
-from grpc_status import rpc_status
-from google.rpc.error_details_pb2 import ErrorInfo
-from google.rpc import code_pb2
+from grpc_status import rpc_status  # type: ignore
+from google.rpc.error_details_pb2 import ErrorInfo  # type: ignore
+from google.rpc import code_pb2  # type: ignore
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1 import subscriber
@@ -867,7 +867,7 @@ class StreamingPullManager(object):
         # Return the initial request.
         return request
 
-    def _send_lease_modacks(self, ack_ids: Sequence[str], ack_deadline: int):
+    def _send_lease_modacks(self, ack_ids: Iterable[str], ack_deadline: float):
         exactly_once_enabled = False
         with self._exactly_once_enabled_lock:
             exactly_once_enabled = self._exactly_once_enabled
@@ -883,6 +883,7 @@ class StreamingPullManager(object):
 
             for req in items:
                 try:
+                    assert req.future is not None
                     req.future.result()
                 except AcknowledgeError:
                     _LOGGER.warning(

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -45,11 +45,11 @@ from google.pubsub_v1 import types as gapic_types
 from grpc_status import rpc_status  # type: ignore
 from google.rpc.error_details_pb2 import ErrorInfo  # type: ignore
 from google.rpc import code_pb2  # type: ignore
+from google.rpc import status_pb2
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1 import subscriber
     from google.protobuf.internal import containers
-    from google.rpc import status_pb2
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -575,6 +575,10 @@ class StreamingPullManager(object):
             error_status = _get_status(exc)
             ack_errors_dict = _get_ack_errors(exc)
         except exceptions.RetryError as exc:
+            status = status_pb2.Status()
+            status.code = code_pb2.DEADLINE_EXCEEDED
+            # Makes sure to complete futures so they don't block forever.
+            _process_futures(status, future_reqs_dict, None)
             _LOGGER.debug(
                 "RetryError while sending unary RPC. Waiting on a transient "
                 "error resolution for too long, will now trigger shutdown.",
@@ -625,6 +629,10 @@ class StreamingPullManager(object):
             error_status = _get_status(exc)
             modack_errors_dict = _get_ack_errors(exc)
         except exceptions.RetryError as exc:
+            status = status_pb2.Status()
+            status.code = code_pb2.DEADLINE_EXCEEDED
+            # Makes sure to complete futures so they don't block forever.
+            _process_futures(status, future_reqs_dict, None)
             _LOGGER.debug(
                 "RetryError while sending unary RPC. Waiting on a transient "
                 "error resolution for too long, will now trigger shutdown.",

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -887,7 +887,7 @@ class StreamingPullManager(object):
                 try:
                     req.future.result()
                 except pubsub_1.subscriber.exceptions.AcknowledgeError as e:
-                    _LOGGER.debug(
+                    _LOGGER.warning(
                         f"AcknowledgeError when modacking a message immediately after receiving it.",
                         exc_info=False,
                     )

--- a/google/cloud/pubsub_v1/subscriber/exceptions.py
+++ b/google/cloud/pubsub_v1/subscriber/exceptions.py
@@ -30,12 +30,12 @@ class AcknowledgeStatus(Enum):
 class AcknowledgeError(GoogleAPICallError):
     """Error during ack/modack/nack operation on exactly-once-enabled subscription."""
 
-    def __init__(self, error_code: str, info: Optional[str]):
+    def __init__(self, error_code: AcknowledgeStatus, info: Optional[str]):
         self.error_code = error_code
         self.info = info
         message = None
         if info:
-            message = str(self.error_code) + " : " + self.info
+            message = str(self.error_code) + " : " + str(self.info)
         else:
             message = str(self.error_code)
         super(AcknowledgeError, self).__init__(message)

--- a/google/cloud/pubsub_v1/subscriber/exceptions.py
+++ b/google/cloud/pubsub_v1/subscriber/exceptions.py
@@ -19,7 +19,7 @@ from google.api_core.exceptions import GoogleAPICallError
 from typing import Optional
 
 
-class AcknowledgeErrorCode(Enum):
+class AcknowledgeStatus(Enum):
     SUCCESS = 1
     PERMISSION_DENIED = 2
     FAILED_PRECONDITION = 3

--- a/google/cloud/pubsub_v1/subscriber/exceptions.py
+++ b/google/cloud/pubsub_v1/subscriber/exceptions.py
@@ -1,0 +1,46 @@
+# Copyright 2017, Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from enum import Enum
+from google.api_core.exceptions import GoogleAPICallError
+from typing import Optional
+
+
+class AcknowledgeErrorCode(Enum):
+    SUCCESS = 1
+    PERMISSION_DENIED = 2
+    FAILED_PRECONDITION = 3
+    INVALID_ACK_ID = 4
+    OTHER = 5
+
+
+class AcknowledgeError(GoogleAPICallError):
+    """Error during ack/modack/nack operation on exactly-once-enabled subscription."""
+
+
+    def __init__(self, error_code: str, info: Optional[str]):
+        self.error_code = error_code
+        self.info = info
+        message = None
+        if info:
+          message = str(self.error_code)  + " : " + self.info
+        else:
+          message = str(self.error_code)
+        super(AcknowledgeError, self).__init__(message)
+
+__all__ = (
+    "AcknowledgeError",
+)

--- a/google/cloud/pubsub_v1/subscriber/exceptions.py
+++ b/google/cloud/pubsub_v1/subscriber/exceptions.py
@@ -30,17 +30,15 @@ class AcknowledgeErrorCode(Enum):
 class AcknowledgeError(GoogleAPICallError):
     """Error during ack/modack/nack operation on exactly-once-enabled subscription."""
 
-
     def __init__(self, error_code: str, info: Optional[str]):
         self.error_code = error_code
         self.info = info
         message = None
         if info:
-          message = str(self.error_code)  + " : " + self.info
+            message = str(self.error_code) + " : " + self.info
         else:
-          message = str(self.error_code)
+            message = str(self.error_code)
         super(AcknowledgeError, self).__init__(message)
 
-__all__ = (
-    "AcknowledgeError",
-)
+
+__all__ = ("AcknowledgeError",)

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 import typing
 from typing import Any
+from typing import Union
 
 from google.cloud.pubsub_v1 import futures
 
@@ -80,3 +81,47 @@ class StreamingPullFuture(futures.Future):
             ``True`` if the subscription has been cancelled.
         """
         return self.__cancelled
+
+
+class Future(futures.Future):
+    # TODO: update docs as necessary
+    """This future object for subscribe-side calls.
+
+    Calling :meth:`result` will resolve the future by returning the message
+    ID, unless an error occurs.
+    """
+
+    def cancel(self) -> bool:
+        """Actions in Pub/Sub generally may not be canceled.
+
+        This method always returns ``False``.
+        """
+        return False
+
+    def cancelled(self) -> bool:
+        """Actions in Pub/Sub generally may not be canceled.
+
+        This method always returns ``False``.
+        """
+        return False
+
+    # TODO modify return type annotation
+    def result(self, timeout: Union[int, float] = None) -> str:
+        """Return the message ID or raise an exception.
+
+        This blocks until the operation completes successfully and
+        returns the error code unless an exception is raised.
+
+        Args:
+            timeout: The number of seconds before this call
+                times out and raises TimeoutError.
+
+        Returns:
+            The message ID.
+
+        Raises:
+            concurrent.futures.TimeoutError: If the request times out.
+            Exception: For undefined exceptions in the underlying
+                call execution.
+        """
+        return super().result(timeout=timeout)

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -19,6 +19,10 @@ from typing import Any
 from typing import Union
 
 from google.cloud.pubsub_v1 import futures
+from google.cloud.pubsub_v1.subscriber.exceptions import (
+    AcknowledgeError,
+    AcknowledgeStatus,
+)
 
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
@@ -84,8 +88,7 @@ class StreamingPullFuture(futures.Future):
 
 
 class Future(futures.Future):
-    # TODO: update docs as necessary
-    """This future object for subscribe-side calls.
+    """This future object is for subscribe-side calls.
 
     Calling :meth:`result` will resolve the future by returning the message
     ID, unless an error occurs.
@@ -105,9 +108,8 @@ class Future(futures.Future):
         """
         return False
 
-    # TODO modify return type annotation
-    def result(self, timeout: Union[int, float] = None) -> str:
-        """Return the message ID or raise an exception.
+    def result(self, timeout: Union[int, float] = None) -> AcknowledgeStatus:
+        """Return a success code or raise an exception.
 
         This blocks until the operation completes successfully and
         returns the error code unless an exception is raised.
@@ -117,11 +119,11 @@ class Future(futures.Future):
                 times out and raises TimeoutError.
 
         Returns:
-            The message ID.
+            AcknowledgeStatus.SUCCESS if the operation succeeded.
 
         Raises:
             concurrent.futures.TimeoutError: If the request times out.
-            Exception: For undefined exceptions in the underlying
-                call execution.
+            AcknowledgeError: If the operation did not succeed for another
+                reason.
         """
         return super().result(timeout=timeout)

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -19,11 +19,7 @@ from typing import Any
 from typing import Union
 
 from google.cloud.pubsub_v1 import futures
-from google.cloud.pubsub_v1.subscriber.exceptions import (
-    AcknowledgeError,
-    AcknowledgeStatus,
-)
-
+from google.cloud.pubsub_v1.subscriber.exceptions import AcknowledgeStatus
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager import (

--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -90,7 +90,7 @@ class Message(object):
         ack_id: str,
         delivery_attempt: int,
         request_queue: "queue.Queue",
-        exactly_once_delivery_enabled_func: Callable[[], bool],
+        exactly_once_delivery_enabled_func: Callable[[], bool] = lambda: False,
     ):
         """Construct the Message.
 
@@ -115,7 +115,7 @@ class Message(object):
                 A queue provided by the policy that can accept requests; the policy is
                 responsible for handling those requests.
             exactly_once_delivery_enabled_func:
-                A Callable that returns whether exactly-once delivery is currently-enabled.
+                A Callable that returns whether exactly-once delivery is currently-enabled. Defaults to a lambda that always returns False.
         """
         self._message = message
         self._ack_id = ack_id

--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -247,7 +247,7 @@ class Message(object):
             )
         )
 
-    def ack_with_response(self) -> "pubsub_v1.subscriber.futures.Future":
+    def ack_with_response(self) -> "futures.Future":
         """Acknowledge the given message.
 
         Acknowledging a message in Pub/Sub means that you are done
@@ -319,9 +319,7 @@ class Message(object):
             requests.ModAckRequest(ack_id=self._ack_id, seconds=seconds, future=None)
         )
 
-    def modify_ack_deadline_with_response(
-        self, seconds: int
-    ) -> "pubsub_v1.subscriber.futures.Future":
+    def modify_ack_deadline_with_response(self, seconds: int) -> "futures.Future":
         """Resets the deadline for acknowledgement and returns the response
         status via a future.
 
@@ -365,7 +363,7 @@ class Message(object):
             )
         )
 
-    def nack_with_response(self) -> "pubsub_v1.subscriber.futures.Future":
+    def nack_with_response(self) -> "futures.Future":
         """Decline to acknowledge the given message, returning the response status via
         a future.
 

--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -243,7 +243,7 @@ class Message(object):
                 byte_size=self.size,
                 time_to_ack=time_to_ack,
                 ordering_key=self.ordering_key,
-                future=None
+                future=None,
             )
         )
 
@@ -275,11 +275,10 @@ class Message(object):
                 byte_size=self.size,
                 time_to_ack=time_to_ack,
                 ordering_key=self.ordering_key,
-                future=future
+                future=future,
             )
         )
         return future
-
 
     def drop(self) -> None:
         """Release the message from lease management.
@@ -320,7 +319,9 @@ class Message(object):
             requests.ModAckRequest(ack_id=self._ack_id, seconds=seconds, future=None)
         )
 
-    def modify_ack_deadline_with_response(self, seconds: int) -> "pubsub_v1.subscriber.futures.Future":
+    def modify_ack_deadline_with_response(
+        self, seconds: int
+    ) -> "pubsub_v1.subscriber.futures.Future":
         """Resets the deadline for acknowledgement and returns the response
         status via a future.
 
@@ -357,8 +358,10 @@ class Message(object):
         """
         self._request_queue.put(
             requests.NackRequest(
-                ack_id=self._ack_id, byte_size=self.size, ordering_key=self.ordering_key,
-                future=None
+                ack_id=self._ack_id,
+                byte_size=self.size,
+                ordering_key=self.ordering_key,
+                future=None,
             )
         )
 
@@ -379,8 +382,10 @@ class Message(object):
         future = futures.Future()
         self._request_queue.put(
             requests.NackRequest(
-                ack_id=self._ack_id, byte_size=self.size, ordering_key=self.ordering_key,
-                future=future
+                ack_id=self._ack_id,
+                byte_size=self.size,
+                ordering_key=self.ordering_key,
+                future=future,
             )
         )
         return future

--- a/google/cloud/pubsub_v1/types.py
+++ b/google/cloud/pubsub_v1/types.py
@@ -166,7 +166,7 @@ class FlowControl(NamedTuple):
     (
         "The min amount of time in seconds for a single lease extension attempt. "
         "Must be between 10 and 600 (inclusive). Ignored by default, but set to "
-        "60 seconds if the subscription has exactly-once enabled."
+        "60 seconds if the subscription has exactly-once delivery enabled."
     )
 
     max_duration_per_lease_extension: float = 0  # disabled by default

--- a/google/cloud/pubsub_v1/types.py
+++ b/google/cloud/pubsub_v1/types.py
@@ -162,6 +162,13 @@ class FlowControl(NamedTuple):
         "before dropping it from the lease management."
     )
 
+    min_duration_per_lease_extension: float = 0
+    (
+        "The min amount of time in seconds for a single lease extension attempt. "
+        "Must be between 10 and 600 (inclusive). Ignored by default, but set to "
+        "60 seconds if the subscription has exactly-once enabled."
+    )
+
     max_duration_per_lease_extension: float = 0  # disabled by default
     (
         "The max amount of time in seconds for a single lease extension attempt. "

--- a/noxfile.py
+++ b/noxfile.py
@@ -229,6 +229,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
+    # Tip: The "-i" flag lets you ignore errors with specific files.
     session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")

--- a/noxfile.py
+++ b/noxfile.py
@@ -159,6 +159,7 @@ def default(session):
         "--cov-config=.coveragerc",
         "--cov-report=",
         "--cov-fail-under=0",
+        "-s",
         os.path.join("tests", "unit"),
         *session.posargs,
     )
@@ -230,7 +231,7 @@ def cover(session):
     """
     session.install("coverage", "pytest-cov")
     # Tip: The "-i" flag lets you ignore errors with specific files.
-    session.run("coverage", "report", "--show-missing", "--fail-under=100")
+    session.run("coverage", "report", "-i", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -204,6 +204,9 @@ def system(session):
     session.install("-e", ".", "-c", constraints_path)
 
     # Run py.test against the system tests.
+    # THe following flags are useful during development:
+    # "-s" -> show print() statement output
+    # "-k <test case prefix>" -> filter test cases
     if system_test_exists:
         session.run(
             "py.test",

--- a/noxfile.py
+++ b/noxfile.py
@@ -146,6 +146,9 @@ def default(session):
     session.install("-e", ".", "-c", constraints_path)
 
     # Run py.test against the unit tests.
+    # THe following flags are useful during development:
+    # "-s" -> show print() statement output
+    # "-k <test case prefix>" -> filter test cases
     session.run(
         "py.test",
         "--quiet",

--- a/noxfile.py
+++ b/noxfile.py
@@ -159,7 +159,6 @@ def default(session):
         "--cov-config=.coveragerc",
         "--cov-report=",
         "--cov-fail-under=0",
-        "-s",
         os.path.join("tests", "unit"),
         *session.posargs,
     )
@@ -231,7 +230,7 @@ def cover(session):
     """
     session.install("coverage", "pytest-cov")
     # Tip: The "-i" flag lets you ignore errors with specific files.
-    session.run("coverage", "report", "-i", "--show-missing", "--fail-under=100")
+    session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")
 

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -606,18 +606,16 @@ def receive_messages_with_exactly_once_subscribe(
         ack_future = message.ack_with_response()
 
         try:
-           # Block on result of acknowledge call.
-           ack_id = ack_future.result()
-           print(f"Ack for id {ack_id} successful.")
-        except RuntimeError as e:
-          # A permanent error indicates the ack_id is no longer valid - retries
-          # will always fail.
-          if "Permanent error" in str(e):
-            print(f"Ack for id {message.ack_id} failed with permanent error: {e}")
-        except Exception as e:
-          # All other errors, including failures after retries, fall here.
-          print(f"An ack error occurred: {e}")
-
+            # Block on result of acknowledge call.
+            ack_id = ack_future.result()
+            print(f"Ack for id {ack_id} successful.")
+        except pubsub_1.subscriber.exceptions.AcknowledgeError as e:
+            print(f"Ack for id {message.ack_id} failed with error: {e.error_code}")
+            if (
+                e.error_code
+                == pubsub_1.subscriber.exceptions.AcknowledgeErrorCode.OTHER
+            ):
+                print(f"Additional error info: {e.info}.")
 
     streaming_pull_future = subscriber.subscribe(subscription_path, callback=callback)
     print(f"Listening for messages on {subscription_path}..\n")

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -580,57 +580,6 @@ def receive_messages_with_blocking_shutdown(
     # [END pubsub_subscriber_blocking_shutdown]
 
 
-def receive_messages_with_exactly_once_subscribe(
-    project_id: str, subscription_id: str, timeout: Optional[float] = None
-) -> None:
-    """Receives messages from a pull subscription with exactly-once delivery enabled."""
-    # [START pubsub_subscriber_async_pull]
-    # [START pubsub_quickstart_subscriber]
-    from concurrent.futures import TimeoutError
-    from google.cloud import pubsub_v1
-    from google.cloud.pubsub_v1.subscriber import sub_exceptions
-
-    # TODO(developer)
-    # project_id = "your-project-id"
-    # subscription_id = "your-subscription-id"
-    # Number of seconds the subscriber should listen for messages
-    # timeout = 5.0
-
-    subscriber = pubsub_v1.SubscriberClient()
-    # The `subscription_path` method creates a fully qualified identifier
-    # in the form `projects/{project_id}/subscriptions/{subscription_id}`
-    subscription_path = subscriber.subscription_path(project_id, subscription_id)
-
-    def callback(message: pubsub_v1.subscriber.message.Message) -> None:
-        print(f"Received {message}.")
-
-        ack_future = message.ack_with_response()
-
-        try:
-            # Block on result of acknowledge call.
-            ack_future.result()
-            print(f"Ack for message {message.message_id} successful.")
-        except sub_exceptions.AcknowledgeError as e:
-            print(
-                f"Ack for message {message.message_id} failed with error: {e.error_code}"
-            )
-
-    streaming_pull_future = subscriber.subscribe(subscription_path, callback=callback)
-    print(f"Listening for messages on {subscription_path}..\n")
-
-    # Wrap subscriber in a 'with' block to automatically call close() when done.
-    with subscriber:
-        try:
-            # When `timeout` is not set, result() will block indefinitely,
-            # unless an exception is encountered first.
-            streaming_pull_future.result(timeout=timeout)
-        except TimeoutError:
-            streaming_pull_future.cancel()  # Trigger the shutdown.
-            streaming_pull_future.result()  # Block until the shutdown is complete.
-    # [END pubsub_subscriber_async_pull]
-    # [END pubsub_quickstart_subscriber]
-
-
 def synchronous_pull(project_id: str, subscription_id: str) -> None:
     """Pulling messages synchronously."""
     # [START pubsub_subscriber_sync_pull]

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -588,6 +588,7 @@ def receive_messages_with_exactly_once_subscribe(
     # [START pubsub_quickstart_subscriber]
     from concurrent.futures import TimeoutError
     from google.cloud import pubsub_v1
+    from google.cloud.pubsub_v1.subscriber import sub_exceptions
 
     # TODO(developer)
     # project_id = "your-project-id"
@@ -609,7 +610,7 @@ def receive_messages_with_exactly_once_subscribe(
             # Block on result of acknowledge call.
             ack_future.result()
             print(f"Ack for message {message.message_id} successful.")
-        except pubsub_1.subscriber.exceptions.AcknowledgeError as e:
+        except sub_exceptions.AcknowledgeError as e:
             print(
                 f"Ack for message {message.message_id} failed with error: {e.error_code}"
             )

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -583,7 +583,7 @@ def receive_messages_with_blocking_shutdown(
 def receive_messages_with_exactly_once_subscribe(
     project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
-    """Receives messages from a pull subscription with exactly-once enabled."""
+    """Receives messages from a pull subscription with exactly-once delivery enabled."""
     # [START pubsub_subscriber_async_pull]
     # [START pubsub_quickstart_subscriber]
     from concurrent.futures import TimeoutError
@@ -607,15 +607,12 @@ def receive_messages_with_exactly_once_subscribe(
 
         try:
             # Block on result of acknowledge call.
-            ack_id = ack_future.result()
-            print(f"Ack for id {ack_id} successful.")
+            ack_future.result()
+            print(f"Ack for message {message.message_id} successful.")
         except pubsub_1.subscriber.exceptions.AcknowledgeError as e:
-            print(f"Ack for id {message.ack_id} failed with error: {e.error_code}")
-            if (
-                e.error_code
-                == pubsub_1.subscriber.exceptions.AcknowledgeErrorCode.OTHER
-            ):
-                print(f"Additional error info: {e.info}.")
+            print(
+                f"Ack for message {message.message_id} failed with error: {e.error_code}"
+            )
 
     streaming_pull_future = subscriber.subscribe(subscription_path, callback=callback)
     print(f"Listening for messages on {subscription_path}..\n")

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -580,6 +580,61 @@ def receive_messages_with_blocking_shutdown(
     # [END pubsub_subscriber_blocking_shutdown]
 
 
+def receive_messages_with_exactly_once_subscribe(
+    project_id: str, subscription_id: str, timeout: Optional[float] = None
+) -> None:
+    """Receives messages from a pull subscription with exactly-once enabled."""
+    # [START pubsub_subscriber_async_pull]
+    # [START pubsub_quickstart_subscriber]
+    from concurrent.futures import TimeoutError
+    from google.cloud import pubsub_v1
+
+    # TODO(developer)
+    # project_id = "your-project-id"
+    # subscription_id = "your-subscription-id"
+    # Number of seconds the subscriber should listen for messages
+    # timeout = 5.0
+
+    subscriber = pubsub_v1.SubscriberClient()
+    # The `subscription_path` method creates a fully qualified identifier
+    # in the form `projects/{project_id}/subscriptions/{subscription_id}`
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
+
+    def callback(message: pubsub_v1.subscriber.message.Message) -> None:
+        print(f"Received {message}.")
+
+        ack_future = message.ack_with_response()
+
+        try:
+           # Block on result of acknowledge call.
+           ack_id = ack_future.result()
+           print(f"Ack for id {ack_id} successful.")
+        except RuntimeError as e:
+          # A permanent error indicates the ack_id is no longer valid - retries
+          # will always fail.
+          if "Permanent error" in str(e):
+            print(f"Ack for id {message.ack_id} failed with permanent error: {e}")
+        except Exception as e:
+          # All other errors, including failures after retries, fall here.
+          print(f"An ack error occurred: {e}")
+
+
+    streaming_pull_future = subscriber.subscribe(subscription_path, callback=callback)
+    print(f"Listening for messages on {subscription_path}..\n")
+
+    # Wrap subscriber in a 'with' block to automatically call close() when done.
+    with subscriber:
+        try:
+            # When `timeout` is not set, result() will block indefinitely,
+            # unless an exception is encountered first.
+            streaming_pull_future.result(timeout=timeout)
+        except TimeoutError:
+            streaming_pull_future.cancel()  # Trigger the shutdown.
+            streaming_pull_future.result()  # Block until the shutdown is complete.
+    # [END pubsub_subscriber_async_pull]
+    # [END pubsub_quickstart_subscriber]
+
+
 def synchronous_pull(project_id: str, subscription_id: str) -> None:
     """Pulling messages synchronously."""
     # [START pubsub_subscriber_sync_pull]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
     "proto-plus >= 1.7.1",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
-    "grpc-status >= 1.0.0",
+    "grpcio-status >= 1.43.0",
 ]
 extras = {"libcst": "libcst >= 0.3.10"}
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
     "proto-plus >= 1.7.1",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
+    "grpc-status >= 1.0.0",
 ]
 extras = {"libcst": "libcst >= 0.3.10"}
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
     "proto-plus >= 1.7.1",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
-    "grpcio-status >= 1.43.0",
+    "grpcio-status >= 1.16.0",
 ]
 extras = {"libcst": "libcst >= 0.3.10"}
 

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -402,7 +402,6 @@ def test_modify_ack_deadline_splitting_large_payload():
 
     for call in calls:
         modack_ackids = call[1]["modify_deadline_ack_ids"]
-        print(type(modack_ackids))
         assert len(modack_ackids) <= dispatcher._ACK_IDS_BATCH_SIZE
         sent_ack_ids.update(modack_ackids)
 

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -83,14 +83,19 @@ def test_ack():
 
     items = [
         requests.AckRequest(
-            ack_id="ack_id_string", byte_size=0, time_to_ack=20, ordering_key="",
-            future=None
+            ack_id="ack_id_string",
+            byte_size=0,
+            time_to_ack=20,
+            ordering_key="",
+            future=None,
         )
     ]
     manager.send_unary_ack.return_value = (items, [])
     dispatcher_.ack(items)
 
-    manager.send_unary_ack.assert_called_once_with(ack_ids=["ack_id_string"], future_reqs_dict={})
+    manager.send_unary_ack.assert_called_once_with(
+        ack_ids=["ack_id_string"], future_reqs_dict={}
+    )
 
     manager.leaser.remove.assert_called_once_with(items)
     manager.maybe_resume_consumer.assert_called_once()
@@ -105,14 +110,19 @@ def test_ack_no_time():
 
     items = [
         requests.AckRequest(
-            ack_id="ack_id_string", byte_size=0, time_to_ack=None, ordering_key="",
-            future=None
+            ack_id="ack_id_string",
+            byte_size=0,
+            time_to_ack=None,
+            ordering_key="",
+            future=None,
         )
     ]
     manager.send_unary_ack.return_value = (items, [])
     dispatcher_.ack(items)
 
-    manager.send_unary_ack.assert_called_once_with(ack_ids=["ack_id_string"], future_reqs_dict={})
+    manager.send_unary_ack.assert_called_once_with(
+        ack_ids=["ack_id_string"], future_reqs_dict={}
+    )
 
     manager.ack_histogram.add.assert_not_called()
 
@@ -126,8 +136,11 @@ def test_ack_splitting_large_payload():
     items = [
         # use realistic lengths for ACK IDs (max 176 bytes)
         requests.AckRequest(
-            ack_id=str(i).zfill(176), byte_size=0, time_to_ack=20, ordering_key="",
-            future=None
+            ack_id=str(i).zfill(176),
+            byte_size=0,
+            time_to_ack=20,
+            ordering_key="",
+            future=None,
         )
         for i in range(5001)
     ]
@@ -205,13 +218,17 @@ def test_nack():
     dispatcher_ = dispatcher.Dispatcher(manager, mock.sentinel.queue)
 
     items = [
-        requests.NackRequest(ack_id="ack_id_string", byte_size=10, ordering_key="", future=None)
+        requests.NackRequest(
+            ack_id="ack_id_string", byte_size=10, ordering_key="", future=None
+        )
     ]
     manager.send_unary_modack.return_value = (items, [])
     dispatcher_.nack(items)
 
     manager.send_unary_modack.assert_called_once_with(
-        modify_deadline_ack_ids=["ack_id_string"], modify_deadline_seconds=[0], future_reqs_dict={}
+        modify_deadline_ack_ids=["ack_id_string"],
+        modify_deadline_seconds=[0],
+        future_reqs_dict={},
     )
 
 
@@ -226,7 +243,9 @@ def test_modify_ack_deadline():
     dispatcher_.modify_ack_deadline(items)
 
     manager.send_unary_modack.assert_called_once_with(
-        modify_deadline_ack_ids=["ack_id_string"], modify_deadline_seconds=[60], future_reqs_dict={}
+        modify_deadline_ack_ids=["ack_id_string"],
+        modify_deadline_seconds=[60],
+        future_reqs_dict={},
     )
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -105,7 +105,7 @@ def test_ack():
     dispatcher_.ack(items)
 
     manager.send_unary_ack.assert_called_once_with(
-        ack_ids=["ack_id_string"], future_reqs_dict={}
+        ack_ids=["ack_id_string"], future_reqs_dict={"ack_id_string": items[0]}
     )
 
     manager.leaser.remove.assert_called_once_with(items)
@@ -132,7 +132,7 @@ def test_ack_no_time():
     dispatcher_.ack(items)
 
     manager.send_unary_ack.assert_called_once_with(
-        ack_ids=["ack_id_string"], future_reqs_dict={}
+        ack_ids=["ack_id_string"], future_reqs_dict={"ack_id_string": items[0]}
     )
 
     manager.ack_histogram.add.assert_not_called()
@@ -359,7 +359,11 @@ def test_nack():
     manager.send_unary_modack.assert_called_once_with(
         modify_deadline_ack_ids=["ack_id_string"],
         modify_deadline_seconds=[0],
-        future_reqs_dict={},
+        future_reqs_dict={
+            "ack_id_string": requests.ModAckRequest(
+                ack_id="ack_id_string", seconds=0, future=None
+            )
+        },
     )
 
 
@@ -376,7 +380,7 @@ def test_modify_ack_deadline():
     manager.send_unary_modack.assert_called_once_with(
         modify_deadline_ack_ids=["ack_id_string"],
         modify_deadline_seconds=[60],
-        future_reqs_dict={},
+        future_reqs_dict={"ack_id_string": items[0]},
     )
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -20,7 +20,6 @@ from google.cloud.pubsub_v1.subscriber._protocol import dispatcher
 from google.cloud.pubsub_v1.subscriber._protocol import helper_threads
 from google.cloud.pubsub_v1.subscriber._protocol import requests
 from google.cloud.pubsub_v1.subscriber._protocol import streaming_pull_manager
-from google.pubsub_v1 import types as gapic_types
 
 import mock
 import pytest

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -75,6 +75,17 @@ def test_dispatch_callback_inactive_manager(item, method_name):
     method.assert_called_once_with([item])
 
 
+def test_unknown_request_type():
+    manager = mock.create_autospec(
+        streaming_pull_manager.StreamingPullManager, instance=True
+    )
+    dispatcher_ = dispatcher.Dispatcher(manager, mock.sentinel.queue)
+
+    items = ["a random string, not a known request type"]
+    manager.send_unary_ack.return_value = (items, [])
+    dispatcher_.dispatch_callback(items)
+
+
 def test_ack():
     manager = mock.create_autospec(
         streaming_pull_manager.StreamingPullManager, instance=True

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -105,7 +105,7 @@ def test_ack():
     dispatcher_.ack(items)
 
     manager.send_unary_ack.assert_called_once_with(
-        ack_ids=["ack_id_string"], future_reqs_dict={"ack_id_string": items[0]}
+        ack_ids=["ack_id_string"], ack_reqs_dict={"ack_id_string": items[0]}
     )
 
     manager.leaser.remove.assert_called_once_with(items)
@@ -132,7 +132,7 @@ def test_ack_no_time():
     dispatcher_.ack(items)
 
     manager.send_unary_ack.assert_called_once_with(
-        ack_ids=["ack_id_string"], future_reqs_dict={"ack_id_string": items[0]}
+        ack_ids=["ack_id_string"], ack_reqs_dict={"ack_id_string": items[0]}
     )
 
     manager.ack_histogram.add.assert_not_called()
@@ -226,13 +226,13 @@ def test_retry_acks():
     manager.send_unary_ack.assert_has_calls(
         [
             mock.call(
-                ack_ids=["ack_id_string"], future_reqs_dict={"ack_id_string": items[0]}
+                ack_ids=["ack_id_string"], ack_reqs_dict={"ack_id_string": items[0]}
             ),
             mock.call(
-                ack_ids=["ack_id_string"], future_reqs_dict={"ack_id_string": items[0]}
+                ack_ids=["ack_id_string"], ack_reqs_dict={"ack_id_string": items[0]}
             ),
             mock.call(
-                ack_ids=["ack_id_string"], future_reqs_dict={"ack_id_string": items[0]}
+                ack_ids=["ack_id_string"], ack_reqs_dict={"ack_id_string": items[0]}
             ),
         ]
     )
@@ -277,17 +277,17 @@ def test_retry_modacks():
             mock.call(
                 modify_deadline_ack_ids=["ack_id_string"],
                 modify_deadline_seconds=[20],
-                future_reqs_dict={"ack_id_string": items[0]},
+                ack_reqs_dict={"ack_id_string": items[0]},
             ),
             mock.call(
                 modify_deadline_ack_ids=["ack_id_string"],
                 modify_deadline_seconds=[20],
-                future_reqs_dict={"ack_id_string": items[0]},
+                ack_reqs_dict={"ack_id_string": items[0]},
             ),
             mock.call(
                 modify_deadline_ack_ids=["ack_id_string"],
                 modify_deadline_seconds=[20],
-                future_reqs_dict={"ack_id_string": items[0]},
+                ack_reqs_dict={"ack_id_string": items[0]},
             ),
         ]
     )
@@ -359,7 +359,7 @@ def test_nack():
     manager.send_unary_modack.assert_called_once_with(
         modify_deadline_ack_ids=["ack_id_string"],
         modify_deadline_seconds=[0],
-        future_reqs_dict={
+        ack_reqs_dict={
             "ack_id_string": requests.ModAckRequest(
                 ack_id="ack_id_string", seconds=0, future=None
             )
@@ -380,7 +380,7 @@ def test_modify_ack_deadline():
     manager.send_unary_modack.assert_called_once_with(
         modify_deadline_ack_ids=["ack_id_string"],
         modify_deadline_seconds=[60],
-        future_reqs_dict={"ack_id_string": items[0]},
+        ack_reqs_dict={"ack_id_string": items[0]},
     )
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -105,5 +105,5 @@ class TestFuture(object):
         )
         with pytest.raises(AcknowledgeError) as e:
             future.result()
-            assert e.error_code == AcknowledgeStatus.PERMISSION_DENIED
-            assert e.info == "Something bad happened."
+        assert e.value.error_code == AcknowledgeStatus.PERMISSION_DENIED
+        assert e.value.info == "Something bad happened."

--- a/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -98,7 +98,11 @@ class TestFuture(object):
 
     def test_result_on_failure(self):
         future = futures.Future()
-        future.set_exception(AcknowledgeError(AcknowledgeStatus.PERMISSION_DENIED, "Something bad happened."))
+        future.set_exception(
+            AcknowledgeError(
+                AcknowledgeStatus.PERMISSION_DENIED, "Something bad happened."
+            )
+        )
         with pytest.raises(AcknowledgeError) as e:
             future.result()
             assert e.error_code == AcknowledgeStatus.PERMISSION_DENIED

--- a/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -19,6 +19,10 @@ import pytest
 
 from google.cloud.pubsub_v1.subscriber import futures
 from google.cloud.pubsub_v1.subscriber._protocol import streaming_pull_manager
+from google.cloud.pubsub_v1.subscriber.exceptions import (
+    AcknowledgeError,
+    AcknowledgeStatus,
+)
 
 
 class TestStreamingPullFuture(object):
@@ -76,3 +80,26 @@ class TestStreamingPullFuture(object):
 
         manager.close.assert_called_once()
         assert future.cancelled()
+
+
+class TestFuture(object):
+    def test_cancel(self):
+        future = futures.Future()
+        assert future.cancel() is False
+
+    def test_cancelled(self):
+        future = futures.Future()
+        assert future.cancelled() is False
+
+    def test_result_on_success(self):
+        future = futures.Future()
+        future.set_result(AcknowledgeStatus.SUCCESS)
+        assert future.result() == AcknowledgeStatus.SUCCESS
+
+    def test_result_on_failure(self):
+        future = futures.Future()
+        future.set_exception(AcknowledgeError(AcknowledgeStatus.PERMISSION_DENIED, "Something bad happened."))
+        with pytest.raises(AcknowledgeError) as e:
+            future.result()
+            assert e.error_code == AcknowledgeStatus.PERMISSION_DENIED
+            assert e.info == "Something bad happened."

--- a/tests/unit/pubsub_v1/subscriber/test_leaser.py
+++ b/tests/unit/pubsub_v1/subscriber/test_leaser.py
@@ -102,7 +102,7 @@ def test_maintain_leases_inactive_manager(caplog):
     leaser_.maintain_leases()
 
     # Leases should still be maintained even if the manager is inactive.
-    manager.dispatcher.modify_ack_deadline.assert_called()
+    manager._send_lease_modacks.assert_called()
     assert "exiting" in caplog.text
 
 
@@ -138,9 +138,11 @@ def test_maintain_leases_ack_ids():
 
     leaser_.maintain_leases()
 
-    manager.dispatcher.modify_ack_deadline.assert_called_once_with(
-        [requests.ModAckRequest(ack_id="my ack id", seconds=10, future=None)]
-    )
+    assert len(manager._send_lease_modacks.mock_calls) == 1
+    call = manager._send_lease_modacks.mock_calls[0]
+    ack_ids = list(call.args[0])
+    assert ack_ids == ["my ack id"]
+    assert call.args[1] == 10
 
 
 def test_maintain_leases_no_ack_ids():
@@ -182,14 +184,11 @@ def test_maintain_leases_outdated_items(time):
     leaser_.maintain_leases()
 
     # ack2, ack3, and ack4 should be renewed. ack1 should've been dropped
-    modacks = manager.dispatcher.modify_ack_deadline.call_args.args[0]
-    expected = [
-        requests.ModAckRequest(ack_id="ack2", seconds=10, future=None),
-        requests.ModAckRequest(ack_id="ack3", seconds=10, future=None),
-        requests.ModAckRequest(ack_id="ack4", seconds=10, future=None),
-    ]
-    # Use sorting to allow for ordering variance.
-    assert sorted(modacks) == sorted(expected)
+    assert len(manager._send_lease_modacks.mock_calls) == 1
+    call = manager._send_lease_modacks.mock_calls[0]
+    ack_ids = list(call.args[0])
+    assert ack_ids == ["ack2", "ack3", "ack4"]
+    assert call.args[1] == 10
 
     manager.dispatcher.drop.assert_called_once_with(
         [requests.DropRequest(ack_id="ack1", byte_size=50, ordering_key="")]

--- a/tests/unit/pubsub_v1/subscriber/test_leaser.py
+++ b/tests/unit/pubsub_v1/subscriber/test_leaser.py
@@ -139,7 +139,7 @@ def test_maintain_leases_ack_ids():
     leaser_.maintain_leases()
 
     manager.dispatcher.modify_ack_deadline.assert_called_once_with(
-        [requests.ModAckRequest(ack_id="my ack id", seconds=10)]
+        [requests.ModAckRequest(ack_id="my ack id", seconds=10, future=None)]
     )
 
 
@@ -184,9 +184,9 @@ def test_maintain_leases_outdated_items(time):
     # ack2, ack3, and ack4 should be renewed. ack1 should've been dropped
     modacks = manager.dispatcher.modify_ack_deadline.call_args.args[0]
     expected = [
-        requests.ModAckRequest(ack_id="ack2", seconds=10),
-        requests.ModAckRequest(ack_id="ack3", seconds=10),
-        requests.ModAckRequest(ack_id="ack4", seconds=10),
+        requests.ModAckRequest(ack_id="ack2", seconds=10, future=None),
+        requests.ModAckRequest(ack_id="ack3", seconds=10, future=None),
+        requests.ModAckRequest(ack_id="ack4", seconds=10, future=None),
     ]
     # Use sorting to allow for ordering variance.
     assert sorted(modacks) == sorted(expected)

--- a/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -127,6 +127,7 @@ def test_ack():
                 byte_size=30,
                 time_to_ack=mock.ANY,
                 ordering_key="",
+                future=None
             )
         )
         check_call_types(put, requests.AckRequest)
@@ -147,7 +148,7 @@ def test_modify_ack_deadline():
     with mock.patch.object(msg._request_queue, "put") as put:
         msg.modify_ack_deadline(60)
         put.assert_called_once_with(
-            requests.ModAckRequest(ack_id="bogus_ack_id", seconds=60)
+            requests.ModAckRequest(ack_id="bogus_ack_id", seconds=60, future=None)
         )
         check_call_types(put, requests.ModAckRequest)
 
@@ -157,7 +158,7 @@ def test_nack():
     with mock.patch.object(msg._request_queue, "put") as put:
         msg.nack()
         put.assert_called_once_with(
-            requests.NackRequest(ack_id="bogus_ack_id", byte_size=30, ordering_key="")
+            requests.NackRequest(ack_id="bogus_ack_id", byte_size=30, ordering_key="", future=None)
         )
         check_call_types(put, requests.NackRequest)
 

--- a/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -202,6 +202,7 @@ def test_nack_with_response():
         )
         check_call_types(put, requests.NackRequest)
 
+
 def test_repr():
     data = b"foo"
     ordering_key = "ord_key"

--- a/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -133,6 +133,22 @@ def test_ack():
         check_call_types(put, requests.AckRequest)
 
 
+def test_ack_with_response():
+    msg = create_message(b"foo", ack_id="bogus_ack_id")
+    with mock.patch.object(msg._request_queue, "put") as put:
+        future = msg.ack_with_response()
+        put.assert_called_once_with(
+            requests.AckRequest(
+                ack_id="bogus_ack_id",
+                byte_size=30,
+                time_to_ack=mock.ANY,
+                ordering_key="",
+                future=future,
+            )
+        )
+        check_call_types(put, requests.AckRequest)
+
+
 def test_drop():
     msg = create_message(b"foo", ack_id="bogus_ack_id")
     with mock.patch.object(msg._request_queue, "put") as put:
@@ -153,6 +169,16 @@ def test_modify_ack_deadline():
         check_call_types(put, requests.ModAckRequest)
 
 
+def test_modify_ack_deadline_with_response():
+    msg = create_message(b"foo", ack_id="bogus_ack_id")
+    with mock.patch.object(msg._request_queue, "put") as put:
+        future = msg.modify_ack_deadline_with_response(60)
+        put.assert_called_once_with(
+            requests.ModAckRequest(ack_id="bogus_ack_id", seconds=60, future=future)
+        )
+        check_call_types(put, requests.ModAckRequest)
+
+
 def test_nack():
     msg = create_message(b"foo", ack_id="bogus_ack_id")
     with mock.patch.object(msg._request_queue, "put") as put:
@@ -164,6 +190,17 @@ def test_nack():
         )
         check_call_types(put, requests.NackRequest)
 
+
+def test_nack_with_response():
+    msg = create_message(b"foo", ack_id="bogus_ack_id")
+    with mock.patch.object(msg._request_queue, "put") as put:
+        future = msg.nack_with_response()
+        put.assert_called_once_with(
+            requests.NackRequest(
+                ack_id="bogus_ack_id", byte_size=30, ordering_key="", future=future
+            )
+        )
+        check_call_types(put, requests.NackRequest)
 
 def test_repr():
     data = b"foo"

--- a/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -127,7 +127,7 @@ def test_ack():
                 byte_size=30,
                 time_to_ack=mock.ANY,
                 ordering_key="",
-                future=None
+                future=None,
             )
         )
         check_call_types(put, requests.AckRequest)
@@ -158,7 +158,9 @@ def test_nack():
     with mock.patch.object(msg._request_queue, "put") as put:
         msg.nack()
         put.assert_called_once_with(
-            requests.NackRequest(ack_id="bogus_ack_id", byte_size=30, ordering_key="", future=None)
+            requests.NackRequest(
+                ack_id="bogus_ack_id", byte_size=30, ordering_key="", future=None
+            )
         )
         check_call_types(put, requests.NackRequest)
 

--- a/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -23,6 +23,7 @@ from google.cloud.pubsub_v1.subscriber import message
 from google.cloud.pubsub_v1.subscriber._protocol import requests
 from google.protobuf import timestamp_pb2
 from google.pubsub_v1 import types as gapic_types
+from google.cloud.pubsub_v1.subscriber.exceptions import AcknowledgeStatus
 
 
 RECEIVED = datetime.datetime(2012, 4, 21, 15, 0, tzinfo=datetime.timezone.utc)
@@ -32,7 +33,14 @@ PUBLISHED = RECEIVED + datetime.timedelta(days=1, microseconds=PUBLISHED_MICROS)
 PUBLISHED_SECONDS = datetime_helpers.to_milliseconds(PUBLISHED) // 1000
 
 
-def create_message(data, ack_id="ACKID", delivery_attempt=0, ordering_key="", **attrs):
+def create_message(
+    data,
+    ack_id="ACKID",
+    delivery_attempt=0,
+    ordering_key="",
+    exactly_once_delivery_enabled=False,
+    **attrs
+):
     with mock.patch.object(time, "time") as time_:
         time_.return_value = RECEIVED_SECONDS
         gapic_pubsub_message = gapic_types.PubsubMessage(
@@ -51,6 +59,7 @@ def create_message(data, ack_id="ACKID", delivery_attempt=0, ordering_key="", **
             ack_id=ack_id,
             delivery_attempt=delivery_attempt,
             request_queue=queue.Queue(),
+            exactly_once_delivery_enabled_func=lambda: exactly_once_delivery_enabled,
         )
         return msg
 
@@ -133,8 +142,27 @@ def test_ack():
         check_call_types(put, requests.AckRequest)
 
 
-def test_ack_with_response():
+def test_ack_with_response_exactly_once_delivery_disabled():
     msg = create_message(b"foo", ack_id="bogus_ack_id")
+    with mock.patch.object(msg._request_queue, "put") as put:
+        future = msg.ack_with_response()
+        put.assert_called_once_with(
+            requests.AckRequest(
+                ack_id="bogus_ack_id",
+                byte_size=30,
+                time_to_ack=mock.ANY,
+                ordering_key="",
+                future=None,
+            )
+        )
+        assert future.result() == AcknowledgeStatus.SUCCESS
+        check_call_types(put, requests.AckRequest)
+
+
+def test_ack_with_response_exactly_once_delivery_enabled():
+    msg = create_message(
+        b"foo", ack_id="bogus_ack_id", exactly_once_delivery_enabled=True
+    )
     with mock.patch.object(msg._request_queue, "put") as put:
         future = msg.ack_with_response()
         put.assert_called_once_with(
@@ -169,8 +197,21 @@ def test_modify_ack_deadline():
         check_call_types(put, requests.ModAckRequest)
 
 
-def test_modify_ack_deadline_with_response():
+def test_modify_ack_deadline_with_response_exactly_once_delivery_disabled():
     msg = create_message(b"foo", ack_id="bogus_ack_id")
+    with mock.patch.object(msg._request_queue, "put") as put:
+        future = msg.modify_ack_deadline_with_response(60)
+        put.assert_called_once_with(
+            requests.ModAckRequest(ack_id="bogus_ack_id", seconds=60, future=None)
+        )
+        assert future.result() == AcknowledgeStatus.SUCCESS
+        check_call_types(put, requests.ModAckRequest)
+
+
+def test_modify_ack_deadline_with_response_exactly_once_delivery_enabled():
+    msg = create_message(
+        b"foo", ack_id="bogus_ack_id", exactly_once_delivery_enabled=True
+    )
     with mock.patch.object(msg._request_queue, "put") as put:
         future = msg.modify_ack_deadline_with_response(60)
         put.assert_called_once_with(
@@ -191,8 +232,23 @@ def test_nack():
         check_call_types(put, requests.NackRequest)
 
 
-def test_nack_with_response():
+def test_nack_with_response_exactly_once_delivery_disabled():
     msg = create_message(b"foo", ack_id="bogus_ack_id")
+    with mock.patch.object(msg._request_queue, "put") as put:
+        future = msg.nack_with_response()
+        put.assert_called_once_with(
+            requests.NackRequest(
+                ack_id="bogus_ack_id", byte_size=30, ordering_key="", future=None
+            )
+        )
+        assert future.result() == AcknowledgeStatus.SUCCESS
+        check_call_types(put, requests.NackRequest)
+
+
+def test_nack_with_response_exactly_once_delivery_enabled():
+    msg = create_message(
+        b"foo", ack_id="bogus_ack_id", exactly_once_delivery_enabled=True
+    )
     with mock.patch.object(msg._request_queue, "put") as put:
         future = msg.nack_with_response()
         put.assert_called_once_with(

--- a/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
+++ b/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
@@ -20,7 +20,8 @@ from google.pubsub_v1 import types as gapic_types
 
 # Using this function instead of a lambda to satisfy the coverage tool
 def return_false():
-  return False
+    return False
+
 
 def make_message(ack_id, ordering_key):
     proto_msg = gapic_types.PubsubMessage(data=b"Q", ordering_key=ordering_key)

--- a/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
+++ b/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
@@ -18,6 +18,7 @@ from google.cloud.pubsub_v1.subscriber import message
 from google.cloud.pubsub_v1.subscriber._protocol import messages_on_hold
 from google.pubsub_v1 import types as gapic_types
 
+
 # Using this function instead of a lambda to satisfy the coverage tool
 def return_false():
     return False

--- a/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
+++ b/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
@@ -18,6 +18,9 @@ from google.cloud.pubsub_v1.subscriber import message
 from google.cloud.pubsub_v1.subscriber._protocol import messages_on_hold
 from google.pubsub_v1 import types as gapic_types
 
+# Using this function instead of a lambda to satisfy the coverage tool
+def return_false():
+  return False
 
 def make_message(ack_id, ordering_key):
     proto_msg = gapic_types.PubsubMessage(data=b"Q", ordering_key=ordering_key)
@@ -26,7 +29,7 @@ def make_message(ack_id, ordering_key):
         ack_id,
         0,
         queue.Queue(),
-        exactly_once_delivery_enabled_func=lambda: False,
+        exactly_once_delivery_enabled_func=return_false,
     )
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
+++ b/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
@@ -21,7 +21,13 @@ from google.pubsub_v1 import types as gapic_types
 
 def make_message(ack_id, ordering_key):
     proto_msg = gapic_types.PubsubMessage(data=b"Q", ordering_key=ordering_key)
-    return message.Message(proto_msg._pb, ack_id, 0, queue.Queue())
+    return message.Message(
+        proto_msg._pb,
+        ack_id,
+        0,
+        queue.Queue(),
+        exactly_once_delivery_enabled_func=lambda: False,
+    )
 
 
 def test_init():

--- a/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
+++ b/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
@@ -19,11 +19,6 @@ from google.cloud.pubsub_v1.subscriber._protocol import messages_on_hold
 from google.pubsub_v1 import types as gapic_types
 
 
-# Using this function instead of a lambda to satisfy the coverage tool
-def return_false():
-    return False
-
-
 def make_message(ack_id, ordering_key):
     proto_msg = gapic_types.PubsubMessage(data=b"Q", ordering_key=ordering_key)
     return message.Message(
@@ -31,7 +26,7 @@ def make_message(ack_id, ordering_key):
         ack_id,
         0,
         queue.Queue(),
-        exactly_once_delivery_enabled_func=return_false,
+        exactly_once_delivery_enabled_func=lambda: False,  # pragma: NO COVER
     )
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1557,7 +1557,7 @@ def test_process_futures_no_errors():
         None, future_reqs_dict, errors_dict
     )
     assert requests_completed[0].ack_id == "ackid1"
-    assert future.result() == "ackid1"
+    assert future.result() == subscriber_exceptions.AcknowledgeErrorCode.SUCCESS
     assert not requests_to_retry
 
 
@@ -1662,7 +1662,7 @@ def test_process_futures_mixed_success_and_failure_acks():
     assert not requests_to_retry[0].future.done()
     # message with ack_id 'ackid3' succeeds
     assert requests_completed[1].ack_id == "ackid3"
-    assert future3.result() == "ackid3"
+    assert future3.result() == subscriber_exceptions.AcknowledgeErrorCode.SUCCESS
 
 
 def test_process_futures_mixed_success_and_failure_modacks():
@@ -1692,4 +1692,4 @@ def test_process_futures_mixed_success_and_failure_modacks():
     assert not requests_to_retry[0].future.done()
     # message with ack_id 'ackid3' succeeds
     assert requests_completed[1].ack_id == "ackid3"
-    assert future3.result() == "ackid3"
+    assert future3.result() == subscriber_exceptions.AcknowledgeErrorCode.SUCCESS

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1378,10 +1378,16 @@ def test__on_response_disable_exactly_once():
 def test__on_response_exactly_once_immediate_modacks_fail():
     manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
     manager._callback = mock.sentinel.callback
+
     def complete_futures_with_error(*args, **kwargs):
         modack_requests = args[0]
         for req in modack_requests:
-                req.future.set_exception(subscriber_exceptions.AcknowledgeError(subscriber_exceptions.AcknowledgeStatus.SUCCESS, None))
+            req.future.set_exception(
+                subscriber_exceptions.AcknowledgeError(
+                    subscriber_exceptions.AcknowledgeStatus.SUCCESS, None
+                )
+            )
+
     dispatcher.modify_ack_deadline.side_effect = complete_futures_with_error
 
     # Set up the messages.

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -152,8 +152,9 @@ def test__obtain_ack_deadline_no_custom_flow_control_setting():
 
     # Make sure that min_duration_per_lease_extension and
     # max_duration_per_lease_extension is disabled.
-    manager._flow_control = types.FlowControl(min_duration_per_lease_extension=0,
-                                              max_duration_per_lease_extension=0)
+    manager._flow_control = types.FlowControl(
+        min_duration_per_lease_extension=0, max_duration_per_lease_extension=0
+    )
 
     deadline = manager._obtain_ack_deadline(maybe_update=True)
     assert deadline == histogram.MIN_ACK_DEADLINE
@@ -228,10 +229,12 @@ def test__obtain_ack_deadline_with_exactly_once_enabled():
 
     manager = make_manager()
     manager._flow_control = types.FlowControl(
-        min_duration_per_lease_extension=0 # leave as default value
+        min_duration_per_lease_extension=0  # leave as default value
     )
     manager._exactly_once_enabled = True
-    manager.ack_histogram.add(10)  # reduce p99 value below 60s min for exactly_once subscriptions
+    manager.ack_histogram.add(
+        10
+    )  # reduce p99 value below 60s min for exactly_once subscriptions
 
     deadline = manager._obtain_ack_deadline(maybe_update=True)
     # Since the 60-second min ack_deadline value for exactly_once subscriptions
@@ -509,7 +512,7 @@ def test_send_unary_modack():
     manager.send_unary_modack(
         modify_deadline_ack_ids=["ack_id3", "ack_id4", "ack_id5"],
         modify_deadline_seconds=[10, 20, 20],
-        future_reqs_dict={}
+        future_reqs_dict={},
     )
 
     manager._client.modify_ack_deadline.assert_has_calls(
@@ -550,9 +553,11 @@ def test_send_unary_modack_api_call_error(caplog):
     error = exceptions.GoogleAPICallError("The front fell off")
     manager._client.modify_ack_deadline.side_effect = error
 
-    manager.send_unary_modack(modify_deadline_ack_ids=["ack_id_string"],
-                              modify_deadline_seconds=[0],
-                              future_reqs_dict={})
+    manager.send_unary_modack(
+        modify_deadline_ack_ids=["ack_id_string"],
+        modify_deadline_seconds=[0],
+        future_reqs_dict={},
+    )
 
     assert "The front fell off" in caplog.text
 
@@ -585,9 +590,11 @@ def test_send_unary_modack_retry_error(caplog):
     manager._client.modify_ack_deadline.side_effect = error
 
     with pytest.raises(exceptions.RetryError):
-        manager.send_unary_modack(modify_deadline_ack_ids=["ack_id_string"],
-                                  modify_deadline_seconds=[0],
-                                  future_reqs_dict={})
+        manager.send_unary_modack(
+            modify_deadline_ack_ids=["ack_id_string"],
+            modify_deadline_seconds=[0],
+            future_reqs_dict={},
+        )
 
     assert "RetryError while sending unary RPC" in caplog.text
     assert "signaled streaming pull manager shutdown" in caplog.text
@@ -624,9 +631,9 @@ def test_heartbeat_stream_ack_deadline_seconds():
 
     result = manager.heartbeat()
 
-    manager._rpc.send.assert_called_once_with(gapic_types.StreamingPullRequest(
-        stream_ack_deadline_seconds=10
-    ))
+    manager._rpc.send.assert_called_once_with(
+        gapic_types.StreamingPullRequest(stream_ack_deadline_seconds=10)
+    )
     assert result
     # Set to false after a send is initiated.
     assert not manager._send_new_ack_deadline
@@ -973,7 +980,10 @@ def test__on_response_modifies_ack_deadline():
         manager._on_response(response)
 
     dispatcher.modify_ack_deadline.assert_called_once_with(
-        [requests.ModAckRequest("ack_1", 18, None), requests.ModAckRequest("ack_2", 18, None)]
+        [
+            requests.ModAckRequest("ack_1", 18, None),
+            requests.ModAckRequest("ack_2", 18, None),
+        ]
     )
 
 
@@ -1001,10 +1011,9 @@ def test__on_response_modifies_ack_deadline_with_exactly_once_min_lease():
                 message=gapic_types.PubsubMessage(data=b"bar", message_id="2"),
             ),
         ],
-        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
-            exactly_once_delivery_enabled = False
-        )
-
+        subscription_properties=gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled=False
+        ),
     )
 
     # Set up the response with the second set of messages and exactly_once enabled.
@@ -1019,19 +1028,27 @@ def test__on_response_modifies_ack_deadline_with_exactly_once_min_lease():
                 message=gapic_types.PubsubMessage(data=b"bar", message_id="2"),
             ),
         ],
-        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
-            exactly_once_delivery_enabled = True
-        )
-
+        subscription_properties=gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled=True
+        ),
     )
 
     # assertions for the _on_response calls below
     dispatcher.assert_has_calls(
         # assertion 1: mod-acks called with histogram-based lease value
-        dispatcher.modify_ack_deadline([requests.ModAckRequest("ack_1", 10, None), requests.ModAckRequest("ack_2", 10, None)]),
-
+        dispatcher.modify_ack_deadline(
+            [
+                requests.ModAckRequest("ack_1", 10, None),
+                requests.ModAckRequest("ack_2", 10, None),
+            ]
+        ),
         # assertion 2: mod-acks called with 60 sec min lease value for exactly_once subscriptions
-        dispatcher.modify_ack_deadline([requests.ModAckRequest("ack_3", 60, None), requests.ModAckRequest("ack_4", 60, None)])
+        dispatcher.modify_ack_deadline(
+            [
+                requests.ModAckRequest("ack_3", 60, None),
+                requests.ModAckRequest("ack_4", 60, None),
+            ]
+        ),
     )
 
     # exactly_once is still disabled b/c subscription_properties says so
@@ -1064,11 +1081,11 @@ def test__on_response_send_ack_deadline_after_enabling_exactly_once():
             gapic_types.ReceivedMessage(
                 ack_id="ack_1",
                 message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
-            ),
+            )
         ],
-        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
-            exactly_once_delivery_enabled = True
-        )
+        subscription_properties=gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled=True
+        ),
     )
 
     # exactly_once should be enabled after this request b/c subscription_properties says so
@@ -1081,9 +1098,9 @@ def test__on_response_send_ack_deadline_after_enabling_exactly_once():
     result = manager.heartbeat()
 
     # heartbeat request is sent with the 60 sec min lease value for exactly_once subscriptions
-    manager._rpc.send.assert_called_once_with(gapic_types.StreamingPullRequest(
-        stream_ack_deadline_seconds=60
-    ))
+    manager._rpc.send.assert_called_once_with(
+        gapic_types.StreamingPullRequest(stream_ack_deadline_seconds=60)
+    )
 
 
 def test__on_response_no_leaser_overload():
@@ -1112,7 +1129,10 @@ def test__on_response_no_leaser_overload():
     manager._on_response(response)
 
     dispatcher.modify_ack_deadline.assert_called_once_with(
-        [requests.ModAckRequest("fack", 10, None), requests.ModAckRequest("back", 10, None)]
+        [
+            requests.ModAckRequest("fack", 10, None),
+            requests.ModAckRequest("back", 10, None),
+        ]
     )
 
     schedule_calls = scheduler.schedule.mock_calls
@@ -1292,11 +1312,11 @@ def test__on_response_enable_exactly_once():
             gapic_types.ReceivedMessage(
                 ack_id="fack",
                 message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
-            ),
+            )
         ],
-        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
-            exactly_once_delivery_enabled = True
-        )
+        subscription_properties=gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled=True
+        ),
     )
 
     # adjust message bookkeeping in leaser
@@ -1328,11 +1348,11 @@ def test__on_response_disable_exactly_once():
             gapic_types.ReceivedMessage(
                 ack_id="fack",
                 message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
-            ),
+            )
         ],
-        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
-            exactly_once_delivery_enabled = False
-        )
+        subscription_properties=gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled=False
+        ),
     )
 
     # adjust message bookkeeping in leaser
@@ -1434,7 +1454,9 @@ def test_get_ack_errors_unable_to_unpack(from_call, unpack):
     error_info.metadata["ack_1"] = "error1"
     st.details.add().Pack(error_info)
     mock_gprc_call = mock.Mock(spec=grpc.Call)
-    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    exception = exceptions.InternalServerError(
+        "msg", errors=(), response=mock_gprc_call
+    )
     from_call.return_value = st
     # Unpack() failed
     unpack.return_value = None
@@ -1456,7 +1478,9 @@ def test_get_ack_errors_from_call_returned_none(from_call):
     manager = make_manager()
 
     mock_gprc_call = mock.Mock(spec=grpc.Call)
-    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    exception = exceptions.InternalServerError(
+        "msg", errors=(), response=mock_gprc_call
+    )
     from_call.return_value = None
     # rpc_status.from_call() returned None
     assert not streaming_pull_manager._get_ack_errors(exception)
@@ -1467,7 +1491,9 @@ def test_get_ack_errors_value_error_thrown(from_call):
     manager = make_manager()
 
     mock_gprc_call = mock.Mock(spec=grpc.Call)
-    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    exception = exceptions.InternalServerError(
+        "msg", errors=(), response=mock_gprc_call
+    )
     from_call.side_effect = ValueError("val error msg")
     # ValueError thrown, so return None
     assert not streaming_pull_manager._get_ack_errors(exception)
@@ -1484,7 +1510,9 @@ def test_get_ack_errors_happy_case(from_call):
     error_info.metadata["ack_1"] = "error1"
     st.details.add().Pack(error_info)
     mock_gprc_call = mock.Mock(spec=grpc.Call)
-    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    exception = exceptions.InternalServerError(
+        "msg", errors=(), response=mock_gprc_call
+    )
     from_call.side_effect = None
     from_call.return_value = st
     # happy case - errors returned in a map
@@ -1497,7 +1525,9 @@ def test_process_futures_no_requests():
     # no requests so no items in results lists
     future_reqs_dict = {}
     errors_dict = {}
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
     assert not requests_completed
     assert not requests_to_retry
 
@@ -1506,7 +1536,9 @@ def test_process_futures_error_dict_is_none():
     # it's valid to pass in `None` for `errors_dict`
     future_reqs_dict = {}
     errors_dict = None
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
     assert not requests_completed
     assert not requests_to_retry
 
@@ -1515,12 +1547,16 @@ def test_process_futures_no_errors():
     # no errors so request should be completed
     future = futures.Future()
     future_reqs_dict = {
-        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+        "ackid1": requests.AckRequest(
+            ack_id="ackid1", byte_size=0, time_to_ack=20, ordering_key="", future=future
+        )
     }
     errors_dict = {}
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
-    assert requests_completed[0].ack_id == 'ackid1'
-    assert future.result() == 'ackid1'
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
+    assert requests_completed[0].ack_id == "ackid1"
+    assert future.result() == "ackid1"
     assert not requests_to_retry
 
 
@@ -1528,11 +1564,15 @@ def test_process_futures_permanent_error_raises_exception():
     # a permanent error raises an exception
     future = futures.Future()
     future_reqs_dict = {
-        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+        "ackid1": requests.AckRequest(
+            ack_id="ackid1", byte_size=0, time_to_ack=20, ordering_key="", future=future
+        )
     }
-    errors_dict = {'ackid1': 'PERMANENT_FAILURE_INVALID_ACK_ID'}
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
-    assert requests_completed[0].ack_id == 'ackid1'
+    errors_dict = {"ackid1": "PERMANENT_FAILURE_INVALID_ACK_ID"}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
+    assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(RuntimeError) as exc_info:
         future.result()
     assert str(exc_info.value) == "Permanent error: PERMANENT_FAILURE_INVALID_ACK_ID"
@@ -1543,12 +1583,16 @@ def test_process_futures_transient_error_returns_request():
     # a transient error returns the request in `requests_to_retry`
     future = futures.Future()
     future_reqs_dict = {
-        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+        "ackid1": requests.AckRequest(
+            ack_id="ackid1", byte_size=0, time_to_ack=20, ordering_key="", future=future
+        )
     }
-    errors_dict = {'ackid1': 'TRANSIENT_FAILURE_INVALID_ACK_ID'}
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    errors_dict = {"ackid1": "TRANSIENT_FAILURE_INVALID_ACK_ID"}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
     assert not requests_completed
-    assert requests_to_retry[0].ack_id == 'ackid1'
+    assert requests_to_retry[0].ack_id == "ackid1"
     assert not future.done()
 
 
@@ -1556,11 +1600,15 @@ def test_process_futures_unknown_error_raises_exception():
     # an unknown error raises an exception
     future = futures.Future()
     future_reqs_dict = {
-        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+        "ackid1": requests.AckRequest(
+            ack_id="ackid1", byte_size=0, time_to_ack=20, ordering_key="", future=future
+        )
     }
-    errors_dict = {'ackid1': 'unknown_error'}
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
-    assert requests_completed[0].ack_id == 'ackid1'
+    errors_dict = {"ackid1": "unknown_error"}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
+    assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(RuntimeError) as exc_info:
         future.result()
     assert str(exc_info.value) == "Unknown error: unknown_error"
@@ -1573,23 +1621,46 @@ def test_process_futures_mixed_success_and_failure_acks():
     future2 = futures.Future()
     future3 = futures.Future()
     future_reqs_dict = {
-        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future1),
-        'ackid2': requests.AckRequest(ack_id='ackid2', byte_size=0, time_to_ack=20, ordering_key="", future=future2),
-        'ackid3': requests.AckRequest(ack_id='ackid3', byte_size=0, time_to_ack=20, ordering_key="", future=future3)
+        "ackid1": requests.AckRequest(
+            ack_id="ackid1",
+            byte_size=0,
+            time_to_ack=20,
+            ordering_key="",
+            future=future1,
+        ),
+        "ackid2": requests.AckRequest(
+            ack_id="ackid2",
+            byte_size=0,
+            time_to_ack=20,
+            ordering_key="",
+            future=future2,
+        ),
+        "ackid3": requests.AckRequest(
+            ack_id="ackid3",
+            byte_size=0,
+            time_to_ack=20,
+            ordering_key="",
+            future=future3,
+        ),
     }
-    errors_dict = {'ackid1': 'PERMANENT_FAILURE_INVALID_ACK_ID', 'ackid2': 'TRANSIENT_FAILURE_INVALID_ACK_ID'}
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    errors_dict = {
+        "ackid1": "PERMANENT_FAILURE_INVALID_ACK_ID",
+        "ackid2": "TRANSIENT_FAILURE_INVALID_ACK_ID",
+    }
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
     # message with ack_id 'ackid1' fails with an exception
-    assert requests_completed[0].ack_id == 'ackid1'
+    assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(RuntimeError) as exc_info:
         future1.result()
     assert str(exc_info.value) == "Permanent error: PERMANENT_FAILURE_INVALID_ACK_ID"
     # message with ack_id 'ackid2' is to be retried
-    assert requests_to_retry[0].ack_id == 'ackid2'
+    assert requests_to_retry[0].ack_id == "ackid2"
     assert not requests_to_retry[0].future.done()
     # message with ack_id 'ackid3' succeeds
-    assert requests_completed[1].ack_id == 'ackid3'
-    assert future3.result() == 'ackid3'
+    assert requests_completed[1].ack_id == "ackid3"
+    assert future3.result() == "ackid3"
 
 
 def test_process_futures_mixed_success_and_failure_modacks():
@@ -1598,21 +1669,25 @@ def test_process_futures_mixed_success_and_failure_modacks():
     future2 = futures.Future()
     future3 = futures.Future()
     future_reqs_dict = {
-        'ackid1': requests.ModAckRequest(ack_id='ackid1', seconds=60, future=future1),
-        'ackid2': requests.ModAckRequest(ack_id='ackid2', seconds=60, future=future2),
-        'ackid3': requests.ModAckRequest(ack_id='ackid3', seconds=60, future=future3)
+        "ackid1": requests.ModAckRequest(ack_id="ackid1", seconds=60, future=future1),
+        "ackid2": requests.ModAckRequest(ack_id="ackid2", seconds=60, future=future2),
+        "ackid3": requests.ModAckRequest(ack_id="ackid3", seconds=60, future=future3),
     }
-    errors_dict = {'ackid1': 'PERMANENT_FAILURE_INVALID_ACK_ID', 'ackid2': 'TRANSIENT_FAILURE_INVALID_ACK_ID'}
-    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    errors_dict = {
+        "ackid1": "PERMANENT_FAILURE_INVALID_ACK_ID",
+        "ackid2": "TRANSIENT_FAILURE_INVALID_ACK_ID",
+    }
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        future_reqs_dict, errors_dict
+    )
     # message with ack_id 'ackid1' fails with an exception
-    assert requests_completed[0].ack_id == 'ackid1'
+    assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(RuntimeError) as exc_info:
         future1.result()
     assert str(exc_info.value) == "Permanent error: PERMANENT_FAILURE_INVALID_ACK_ID"
     # message with ack_id 'ackid2' is to be retried
-    assert requests_to_retry[0].ack_id == 'ackid2'
+    assert requests_to_retry[0].ack_id == "ackid2"
     assert not requests_to_retry[0].future.done()
     # message with ack_id 'ackid3' succeeds
-    assert requests_completed[1].ack_id == 'ackid3'
-    assert future3.result() == 'ackid3'
-
+    assert requests_completed[1].ack_id == "ackid3"
+    assert future3.result() == "ackid3"

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1557,7 +1557,7 @@ def test_process_futures_no_errors():
         None, future_reqs_dict, errors_dict
     )
     assert requests_completed[0].ack_id == "ackid1"
-    assert future.result() == subscriber_exceptions.AcknowledgeErrorCode.SUCCESS
+    assert future.result() == subscriber_exceptions.AcknowledgeStatus.SUCCESS
     assert not requests_to_retry
 
 
@@ -1576,7 +1576,7 @@ def test_process_futures_permanent_error_raises_exception():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeErrorCode.INVALID_ACK_ID
+    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
     assert not requests_to_retry
 
 
@@ -1612,7 +1612,7 @@ def test_process_futures_unknown_error_raises_exception():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeErrorCode.OTHER
+    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.OTHER
     assert exc_info.value.info == "unknown_error"
     assert not requests_to_retry
 
@@ -1656,13 +1656,13 @@ def test_process_futures_mixed_success_and_failure_acks():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future1.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeErrorCode.INVALID_ACK_ID
+    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
     # message with ack_id 'ackid2' is to be retried
     assert requests_to_retry[0].ack_id == "ackid2"
     assert not requests_to_retry[0].future.done()
     # message with ack_id 'ackid3' succeeds
     assert requests_completed[1].ack_id == "ackid3"
-    assert future3.result() == subscriber_exceptions.AcknowledgeErrorCode.SUCCESS
+    assert future3.result() == subscriber_exceptions.AcknowledgeStatus.SUCCESS
 
 
 def test_process_futures_mixed_success_and_failure_modacks():
@@ -1686,10 +1686,10 @@ def test_process_futures_mixed_success_and_failure_modacks():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future1.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeErrorCode.INVALID_ACK_ID
+    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
     # message with ack_id 'ackid2' is to be retried
     assert requests_to_retry[0].ack_id == "ackid2"
     assert not requests_to_retry[0].future.done()
     # message with ack_id 'ackid3' succeeds
     assert requests_completed[1].ack_id == "ackid3"
-    assert future3.result() == subscriber_exceptions.AcknowledgeErrorCode.SUCCESS
+    assert future3.result() == subscriber_exceptions.AcknowledgeStatus.SUCCESS

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -33,8 +33,14 @@ from google.cloud.pubsub_v1.subscriber._protocol import leaser
 from google.cloud.pubsub_v1.subscriber._protocol import messages_on_hold
 from google.cloud.pubsub_v1.subscriber._protocol import requests
 from google.cloud.pubsub_v1.subscriber._protocol import streaming_pull_manager
+from google.cloud.pubsub_v1.subscriber import futures
 from google.pubsub_v1 import types as gapic_types
+import grpc_status
 import grpc
+from google.rpc import status_pb2
+from google.rpc import code_pb2
+from google.rpc import error_details_pb2
+from google.protobuf.any_pb2 import Any
 
 
 @pytest.mark.parametrize(
@@ -144,8 +150,10 @@ def test__obtain_ack_deadline_no_custom_flow_control_setting():
 
     manager = make_manager()
 
-    # Make sure that max_duration_per_lease_extension is disabled.
-    manager._flow_control = types.FlowControl(max_duration_per_lease_extension=0)
+    # Make sure that min_duration_per_lease_extension and
+    # max_duration_per_lease_extension is disabled.
+    manager._flow_control = types.FlowControl(min_duration_per_lease_extension=0,
+                                              max_duration_per_lease_extension=0)
 
     deadline = manager._obtain_ack_deadline(maybe_update=True)
     assert deadline == histogram.MIN_ACK_DEADLINE
@@ -175,6 +183,20 @@ def test__obtain_ack_deadline_with_max_duration_per_lease_extension():
     assert deadline == histogram.MIN_ACK_DEADLINE + 1
 
 
+def test__obtain_ack_deadline_with_min_duration_per_lease_extension():
+    from google.cloud.pubsub_v1.subscriber._protocol import histogram
+
+    manager = make_manager()
+    manager._flow_control = types.FlowControl(
+        min_duration_per_lease_extension=histogram.MAX_ACK_DEADLINE
+    )
+    manager.ack_histogram.add(histogram.MIN_ACK_DEADLINE)  # make p99 value small
+
+    # The deadline configured in flow control should prevail.
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MAX_ACK_DEADLINE
+
+
 def test__obtain_ack_deadline_with_max_duration_per_lease_extension_too_low():
     from google.cloud.pubsub_v1.subscriber._protocol import histogram
 
@@ -182,11 +204,56 @@ def test__obtain_ack_deadline_with_max_duration_per_lease_extension_too_low():
     manager._flow_control = types.FlowControl(
         max_duration_per_lease_extension=histogram.MIN_ACK_DEADLINE - 1
     )
-    manager.ack_histogram.add(histogram.MIN_ACK_DEADLINE * 3)  # make p99 value large
 
     # The deadline configured in flow control should be adjusted to the minimum allowed.
     deadline = manager._obtain_ack_deadline(maybe_update=True)
     assert deadline == histogram.MIN_ACK_DEADLINE
+
+
+def test__obtain_ack_deadline_with_min_duration_per_lease_extension_too_high():
+    from google.cloud.pubsub_v1.subscriber._protocol import histogram
+
+    manager = make_manager()
+    manager._flow_control = types.FlowControl(
+        min_duration_per_lease_extension=histogram.MAX_ACK_DEADLINE + 1
+    )
+
+    # The deadline configured in flow control should be adjusted to the maximum allowed.
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MAX_ACK_DEADLINE
+
+
+def test__obtain_ack_deadline_with_exactly_once_enabled():
+    from google.cloud.pubsub_v1.subscriber._protocol import histogram
+
+    manager = make_manager()
+    manager._flow_control = types.FlowControl(
+        min_duration_per_lease_extension=0 # leave as default value
+    )
+    manager._exactly_once_enabled = True
+    manager.ack_histogram.add(10)  # reduce p99 value below 60s min for exactly_once subscriptions
+
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    # Since the 60-second min ack_deadline value for exactly_once subscriptions
+    # seconds is higher than the histogram value, the deadline should be 60 sec.
+    assert deadline == 60
+
+
+def test__obtain_ack_deadline_with_min_duration_per_lease_extension_with_exactly_once_enabled():
+    from google.cloud.pubsub_v1.subscriber._protocol import histogram
+
+    manager = make_manager()
+    manager._flow_control = types.FlowControl(
+        min_duration_per_lease_extension=histogram.MAX_ACK_DEADLINE
+    )
+    manager._exactly_once_enabled = True
+    manager.ack_histogram.add(histogram.MIN_ACK_DEADLINE)  # make p99 value small
+
+    # The deadline configured in flow control should prevail.
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    # User-defined custom min ack_deadline value takes precedence over
+    # exactly_once default of 60 seconds.
+    assert deadline == histogram.MAX_ACK_DEADLINE
 
 
 def test__obtain_ack_deadline_no_value_update():
@@ -426,19 +493,23 @@ def test__maybe_release_messages_negative_on_hold_bytes_warning(caplog):
     assert manager._on_hold_bytes == 0  # should be auto-corrected
 
 
-def test_send_unary():
+def test_send_unary_ack():
     manager = make_manager()
 
-    manager.send(
-        gapic_types.StreamingPullRequest(
-            ack_ids=["ack_id1", "ack_id2"],
-            modify_deadline_ack_ids=["ack_id3", "ack_id4", "ack_id5"],
-            modify_deadline_seconds=[10, 20, 20],
-        )
-    )
+    manager.send_unary_ack(ack_ids=["ack_id1", "ack_id2"], future_reqs_dict={})
 
     manager._client.acknowledge.assert_called_once_with(
         subscription=manager._subscription, ack_ids=["ack_id1", "ack_id2"]
+    )
+
+
+def test_send_unary_modack():
+    manager = make_manager()
+
+    manager.send_unary_modack(
+        modify_deadline_ack_ids=["ack_id3", "ack_id4", "ack_id5"],
+        modify_deadline_seconds=[10, 20, 20],
+        future_reqs_dict={}
     )
 
     manager._client.modify_ack_deadline.assert_has_calls(
@@ -458,16 +529,7 @@ def test_send_unary():
     )
 
 
-def test_send_unary_empty():
-    manager = make_manager()
-
-    manager.send(gapic_types.StreamingPullRequest())
-
-    manager._client.acknowledge.assert_not_called()
-    manager._client.modify_ack_deadline.assert_not_called()
-
-
-def test_send_unary_api_call_error(caplog):
+def test_send_unary_ack_api_call_error(caplog):
     caplog.set_level(logging.DEBUG)
 
     manager = make_manager()
@@ -475,12 +537,27 @@ def test_send_unary_api_call_error(caplog):
     error = exceptions.GoogleAPICallError("The front fell off")
     manager._client.acknowledge.side_effect = error
 
-    manager.send(gapic_types.StreamingPullRequest(ack_ids=["ack_id1", "ack_id2"]))
+    manager.send_unary_ack(ack_ids=["ack_id1", "ack_id2"], future_reqs_dict={})
 
     assert "The front fell off" in caplog.text
 
 
-def test_send_unary_retry_error(caplog):
+def test_send_unary_modack_api_call_error(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    manager = make_manager()
+
+    error = exceptions.GoogleAPICallError("The front fell off")
+    manager._client.modify_ack_deadline.side_effect = error
+
+    manager.send_unary_modack(modify_deadline_ack_ids=["ack_id_string"],
+                              modify_deadline_seconds=[0],
+                              future_reqs_dict={})
+
+    assert "The front fell off" in caplog.text
+
+
+def test_send_unary_ack_retry_error(caplog):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -491,7 +568,26 @@ def test_send_unary_retry_error(caplog):
     manager._client.acknowledge.side_effect = error
 
     with pytest.raises(exceptions.RetryError):
-        manager.send(gapic_types.StreamingPullRequest(ack_ids=["ack_id1", "ack_id2"]))
+        manager.send_unary_ack(ack_ids=["ack_id1", "ack_id2"], future_reqs_dict={})
+
+    assert "RetryError while sending unary RPC" in caplog.text
+    assert "signaled streaming pull manager shutdown" in caplog.text
+
+
+def test_send_unary_modack_retry_error(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    manager, _, _, _, _, _ = make_running_manager()
+
+    error = exceptions.RetryError(
+        "Too long a transient error", cause=Exception("Out of time!")
+    )
+    manager._client.modify_ack_deadline.side_effect = error
+
+    with pytest.raises(exceptions.RetryError):
+        manager.send_unary_modack(modify_deadline_ack_ids=["ack_id_string"],
+                                  modify_deadline_seconds=[0],
+                                  future_reqs_dict={})
 
     assert "RetryError while sending unary RPC" in caplog.text
     assert "signaled streaming pull manager shutdown" in caplog.text
@@ -517,6 +613,23 @@ def test_heartbeat_inactive():
 
     result = manager._rpc.send.assert_not_called()
     assert not result
+
+
+def test_heartbeat_stream_ack_deadline_seconds():
+    manager = make_manager()
+    manager._rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
+    manager._rpc.is_active = True
+    # Send new ack deadline with next heartbeat.
+    manager._send_new_ack_deadline = True
+
+    result = manager.heartbeat()
+
+    manager._rpc.send.assert_called_once_with(gapic_types.StreamingPullRequest(
+        stream_ack_deadline_seconds=10
+    ))
+    assert result
+    # Set to false after a send is initiated.
+    assert not manager._send_new_ack_deadline
 
 
 @mock.patch("google.api_core.bidi.ResumableBidiRpc", autospec=True)
@@ -860,8 +973,117 @@ def test__on_response_modifies_ack_deadline():
         manager._on_response(response)
 
     dispatcher.modify_ack_deadline.assert_called_once_with(
-        [requests.ModAckRequest("ack_1", 18), requests.ModAckRequest("ack_2", 18)]
+        [requests.ModAckRequest("ack_1", 18, None), requests.ModAckRequest("ack_2", 18, None)]
     )
+
+
+def test__on_response_modifies_ack_deadline_with_exactly_once_min_lease():
+    # exactly_once is disabled by default.
+    manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
+    manager._callback = mock.sentinel.callback
+
+    # make p99 value smaller than exactly_once min lease
+    manager.ack_histogram.add(10)
+
+    # adjust message bookkeeping in leaser
+    fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=42)
+
+    # Set up the response with the first set of messages and exactly_once not
+    # enabled.
+    response1 = gapic_types.StreamingPullResponse(
+        received_messages=[
+            gapic_types.ReceivedMessage(
+                ack_id="ack_1",
+                message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
+            ),
+            gapic_types.ReceivedMessage(
+                ack_id="ack_2",
+                message=gapic_types.PubsubMessage(data=b"bar", message_id="2"),
+            ),
+        ],
+        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled = False
+        )
+
+    )
+
+    # Set up the response with the second set of messages and exactly_once enabled.
+    response2 = gapic_types.StreamingPullResponse(
+        received_messages=[
+            gapic_types.ReceivedMessage(
+                ack_id="ack_3",
+                message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
+            ),
+            gapic_types.ReceivedMessage(
+                ack_id="ack_4",
+                message=gapic_types.PubsubMessage(data=b"bar", message_id="2"),
+            ),
+        ],
+        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled = True
+        )
+
+    )
+
+    # assertions for the _on_response calls below
+    dispatcher.assert_has_calls(
+        # assertion 1: mod-acks called with histogram-based lease value
+        dispatcher.modify_ack_deadline([requests.ModAckRequest("ack_1", 10, None), requests.ModAckRequest("ack_2", 10, None)]),
+
+        # assertion 2: mod-acks called with 60 sec min lease value for exactly_once subscriptions
+        dispatcher.modify_ack_deadline([requests.ModAckRequest("ack_3", 60, None), requests.ModAckRequest("ack_4", 60, None)])
+    )
+
+    # exactly_once is still disabled b/c subscription_properties says so
+    # should satisfy assertion 1
+    manager._on_response(response1)
+
+    # exactly_once should be enabled after this request b/c subscription_properties says so
+    # should satisfy assertion 2
+    manager._on_response(response2)
+
+
+def test__on_response_send_ack_deadline_after_enabling_exactly_once():
+    # exactly_once is disabled by default.
+    manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
+    manager._callback = mock.sentinel.callback
+
+    # set up an active RPC
+    manager._rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
+    manager._rpc.is_active = True
+
+    # make p99 value smaller than exactly_once min lease
+    manager.ack_histogram.add(10)
+
+    # adjust message bookkeeping in leaser
+    fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=42)
+
+    # Set up the response with the a message and exactly_once enabled.
+    response2 = gapic_types.StreamingPullResponse(
+        received_messages=[
+            gapic_types.ReceivedMessage(
+                ack_id="ack_1",
+                message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
+            ),
+        ],
+        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled = True
+        )
+    )
+
+    # exactly_once should be enabled after this request b/c subscription_properties says so
+    # when exactly_once is enabled or disabled, we send a new ack_deadline via
+    # the heartbeat
+    # should satisfy assertion 1
+    manager._on_response(response2)
+
+    # simulate periodic heartbeat trigger
+    result = manager.heartbeat()
+
+    # heartbeat request is sent with the 60 sec min lease value for exactly_once subscriptions
+    manager._rpc.send.assert_called_once_with(gapic_types.StreamingPullRequest(
+        stream_ack_deadline_seconds=60
+    ))
 
 
 def test__on_response_no_leaser_overload():
@@ -890,7 +1112,7 @@ def test__on_response_no_leaser_overload():
     manager._on_response(response)
 
     dispatcher.modify_ack_deadline.assert_called_once_with(
-        [requests.ModAckRequest("fack", 10), requests.ModAckRequest("back", 10)]
+        [requests.ModAckRequest("fack", 10, None), requests.ModAckRequest("back", 10, None)]
     )
 
     schedule_calls = scheduler.schedule.mock_calls
@@ -937,9 +1159,9 @@ def test__on_response_with_leaser_overload():
     # deadline extended, even those not dispatched to callbacks
     dispatcher.modify_ack_deadline.assert_called_once_with(
         [
-            requests.ModAckRequest("fack", 10),
-            requests.ModAckRequest("back", 10),
-            requests.ModAckRequest("zack", 10),
+            requests.ModAckRequest("fack", 10, None),
+            requests.ModAckRequest("back", 10, None),
+            requests.ModAckRequest("zack", 10, None),
         ]
     )
 
@@ -1017,9 +1239,9 @@ def test__on_response_with_ordering_keys():
     # deadline extended, even those not dispatched to callbacks.
     dispatcher.modify_ack_deadline.assert_called_once_with(
         [
-            requests.ModAckRequest("fack", 10),
-            requests.ModAckRequest("back", 10),
-            requests.ModAckRequest("zack", 10),
+            requests.ModAckRequest("fack", 10, None),
+            requests.ModAckRequest("back", 10, None),
+            requests.ModAckRequest("zack", 10, None),
         ]
     )
 
@@ -1056,6 +1278,74 @@ def test__on_response_with_ordering_keys():
 
     # No messages available in the queue.
     assert manager._messages_on_hold.get() is None
+
+
+def test__on_response_enable_exactly_once():
+    from google.cloud.pubsub_v1.subscriber._protocol import histogram
+
+    manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
+    manager._callback = mock.sentinel.callback
+
+    # Set up the messages.
+    response = gapic_types.StreamingPullResponse(
+        received_messages=[
+            gapic_types.ReceivedMessage(
+                ack_id="fack",
+                message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
+            ),
+        ],
+        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled = True
+        )
+    )
+
+    # adjust message bookkeeping in leaser
+    fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=42)
+
+    # exactly_once should be enabled
+    manager._on_response(response)
+
+    assert manager._exactly_once_enabled
+    # new deadline for exactly_once subscriptions should be used
+    assert manager.ack_deadline == 60
+
+
+def test__on_response_disable_exactly_once():
+    from google.cloud.pubsub_v1.subscriber._protocol import histogram
+
+    manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
+    manager._callback = mock.sentinel.callback
+
+    manager._flow_control = types.FlowControl(
+        min_duration_per_lease_extension=histogram.MIN_ACK_DEADLINE
+    )
+    # enable exactly_once
+    manager._exactly_once_enabled = True
+
+    # Set up the messages.
+    response = gapic_types.StreamingPullResponse(
+        received_messages=[
+            gapic_types.ReceivedMessage(
+                ack_id="fack",
+                message=gapic_types.PubsubMessage(data=b"foo", message_id="1"),
+            ),
+        ],
+        subscription_properties = gapic_types.StreamingPullResponse.SubscriptionProperties(
+            exactly_once_delivery_enabled = False
+        )
+    )
+
+    # adjust message bookkeeping in leaser
+    fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=42)
+
+    # exactly_once should be disabled
+    manager._on_response(response)
+
+    assert not manager._exactly_once_enabled
+    # The deadline configured in flow control should be used, not the
+    # exactly_once minimum since exactly_once has been disabled.
+    deadline = manager._obtain_ack_deadline(maybe_update=True)
+    assert deadline == histogram.MIN_ACK_DEADLINE
 
 
 def test__should_recover_true():
@@ -1130,3 +1420,199 @@ def test_activate_ordering_keys_stopped_scheduler():
     manager.activate_ordering_keys(["key1", "key2"])
 
     manager._messages_on_hold.activate_ordering_keys.assert_not_called()
+
+
+@mock.patch("grpc_status.rpc_status.from_call")
+@mock.patch("google.protobuf.any_pb2.Any.Unpack")
+def test_get_ack_errors_unable_to_unpack(from_call, unpack):
+    manager = make_manager()
+
+    st = status_pb2.Status()
+    st.code = code_pb2.Code.INTERNAL
+    st.message = "qmsg"
+    error_info = error_details_pb2.ErrorInfo()
+    error_info.metadata["ack_1"] = "error1"
+    st.details.add().Pack(error_info)
+    mock_gprc_call = mock.Mock(spec=grpc.Call)
+    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    from_call.return_value = st
+    # Unpack() failed
+    unpack.return_value = None
+
+    assert not streaming_pull_manager._get_ack_errors(exception)
+
+
+@mock.patch("grpc_status.rpc_status.from_call")
+def test_get_ack_errors_no_response_obj(from_call):
+    manager = make_manager()
+
+    exception = exceptions.InternalServerError("msg", errors=(), response=None)
+    # No response obj
+    assert not streaming_pull_manager._get_ack_errors(exception)
+
+
+@mock.patch("grpc_status.rpc_status.from_call")
+def test_get_ack_errors_from_call_returned_none(from_call):
+    manager = make_manager()
+
+    mock_gprc_call = mock.Mock(spec=grpc.Call)
+    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    from_call.return_value = None
+    # rpc_status.from_call() returned None
+    assert not streaming_pull_manager._get_ack_errors(exception)
+
+
+@mock.patch("grpc_status.rpc_status.from_call")
+def test_get_ack_errors_value_error_thrown(from_call):
+    manager = make_manager()
+
+    mock_gprc_call = mock.Mock(spec=grpc.Call)
+    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    from_call.side_effect = ValueError("val error msg")
+    # ValueError thrown, so return None
+    assert not streaming_pull_manager._get_ack_errors(exception)
+
+
+@mock.patch("grpc_status.rpc_status.from_call")
+def test_get_ack_errors_happy_case(from_call):
+    manager = make_manager()
+
+    st = status_pb2.Status()
+    st.code = code_pb2.Code.INTERNAL
+    st.message = "qmsg"
+    error_info = error_details_pb2.ErrorInfo()
+    error_info.metadata["ack_1"] = "error1"
+    st.details.add().Pack(error_info)
+    mock_gprc_call = mock.Mock(spec=grpc.Call)
+    exception = exceptions.InternalServerError("msg", errors=(), response=mock_gprc_call)
+    from_call.side_effect = None
+    from_call.return_value = st
+    # happy case - errors returned in a map
+    ack_errors = streaming_pull_manager._get_ack_errors(exception)
+    assert ack_errors
+    assert ack_errors["ack_1"] == "error1"
+
+
+def test_process_futures_no_requests():
+    # no requests so no items in results lists
+    future_reqs_dict = {}
+    errors_dict = {}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    assert not requests_completed
+    assert not requests_to_retry
+
+
+def test_process_futures_error_dict_is_none():
+    # it's valid to pass in `None` for `errors_dict`
+    future_reqs_dict = {}
+    errors_dict = None
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    assert not requests_completed
+    assert not requests_to_retry
+
+
+def test_process_futures_no_errors():
+    # no errors so request should be completed
+    future = futures.Future()
+    future_reqs_dict = {
+        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+    }
+    errors_dict = {}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    assert requests_completed[0].ack_id == 'ackid1'
+    assert future.result() == 'ackid1'
+    assert not requests_to_retry
+
+
+def test_process_futures_permanent_error_raises_exception():
+    # a permanent error raises an exception
+    future = futures.Future()
+    future_reqs_dict = {
+        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+    }
+    errors_dict = {'ackid1': 'PERMANENT_FAILURE_INVALID_ACK_ID'}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    assert requests_completed[0].ack_id == 'ackid1'
+    with pytest.raises(RuntimeError) as exc_info:
+        future.result()
+    assert str(exc_info.value) == "Permanent error: PERMANENT_FAILURE_INVALID_ACK_ID"
+    assert not requests_to_retry
+
+
+def test_process_futures_transient_error_returns_request():
+    # a transient error returns the request in `requests_to_retry`
+    future = futures.Future()
+    future_reqs_dict = {
+        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+    }
+    errors_dict = {'ackid1': 'TRANSIENT_FAILURE_INVALID_ACK_ID'}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    assert not requests_completed
+    assert requests_to_retry[0].ack_id == 'ackid1'
+    assert not future.done()
+
+
+def test_process_futures_unknown_error_raises_exception():
+    # an unknown error raises an exception
+    future = futures.Future()
+    future_reqs_dict = {
+        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future)
+    }
+    errors_dict = {'ackid1': 'unknown_error'}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    assert requests_completed[0].ack_id == 'ackid1'
+    with pytest.raises(RuntimeError) as exc_info:
+        future.result()
+    assert str(exc_info.value) == "Unknown error: unknown_error"
+    assert not requests_to_retry
+
+
+def test_process_futures_mixed_success_and_failure_acks():
+    # mixed success and failure (acks)
+    future1 = futures.Future()
+    future2 = futures.Future()
+    future3 = futures.Future()
+    future_reqs_dict = {
+        'ackid1': requests.AckRequest(ack_id='ackid1', byte_size=0, time_to_ack=20, ordering_key="", future=future1),
+        'ackid2': requests.AckRequest(ack_id='ackid2', byte_size=0, time_to_ack=20, ordering_key="", future=future2),
+        'ackid3': requests.AckRequest(ack_id='ackid3', byte_size=0, time_to_ack=20, ordering_key="", future=future3)
+    }
+    errors_dict = {'ackid1': 'PERMANENT_FAILURE_INVALID_ACK_ID', 'ackid2': 'TRANSIENT_FAILURE_INVALID_ACK_ID'}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    # message with ack_id 'ackid1' fails with an exception
+    assert requests_completed[0].ack_id == 'ackid1'
+    with pytest.raises(RuntimeError) as exc_info:
+        future1.result()
+    assert str(exc_info.value) == "Permanent error: PERMANENT_FAILURE_INVALID_ACK_ID"
+    # message with ack_id 'ackid2' is to be retried
+    assert requests_to_retry[0].ack_id == 'ackid2'
+    assert not requests_to_retry[0].future.done()
+    # message with ack_id 'ackid3' succeeds
+    assert requests_completed[1].ack_id == 'ackid3'
+    assert future3.result() == 'ackid3'
+
+
+def test_process_futures_mixed_success_and_failure_modacks():
+    # mixed success and failure (modacks)
+    future1 = futures.Future()
+    future2 = futures.Future()
+    future3 = futures.Future()
+    future_reqs_dict = {
+        'ackid1': requests.ModAckRequest(ack_id='ackid1', seconds=60, future=future1),
+        'ackid2': requests.ModAckRequest(ack_id='ackid2', seconds=60, future=future2),
+        'ackid3': requests.ModAckRequest(ack_id='ackid3', seconds=60, future=future3)
+    }
+    errors_dict = {'ackid1': 'PERMANENT_FAILURE_INVALID_ACK_ID', 'ackid2': 'TRANSIENT_FAILURE_INVALID_ACK_ID'}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(future_reqs_dict, errors_dict)
+    # message with ack_id 'ackid1' fails with an exception
+    assert requests_completed[0].ack_id == 'ackid1'
+    with pytest.raises(RuntimeError) as exc_info:
+        future1.result()
+    assert str(exc_info.value) == "Permanent error: PERMANENT_FAILURE_INVALID_ACK_ID"
+    # message with ack_id 'ackid2' is to be retried
+    assert requests_to_retry[0].ack_id == 'ackid2'
+    assert not requests_to_retry[0].future.done()
+    # message with ack_id 'ackid3' succeeds
+    assert requests_completed[1].ack_id == 'ackid3'
+    assert future3.result() == 'ackid3'
+

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1520,7 +1520,7 @@ def test_get_ack_errors_detail_not_error_info(from_call):
     st.message = "qmsg"
     # pack a dummy status instead of an ErrorInfo
     dummy_status = status_pb2.Status()
-    st.details.add().Pack(dummy_status )
+    st.details.add().Pack(dummy_status)
     mock_gprc_call = mock.Mock(spec=grpc.Call)
     exception = exceptions.InternalServerError(
         "msg", errors=(), response=mock_gprc_call
@@ -1664,7 +1664,10 @@ def test_process_futures_permission_denied_error_status_raises_exception():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.PERMISSION_DENIED
+    assert (
+        exc_info.value.error_code
+        == subscriber_exceptions.AcknowledgeStatus.PERMISSION_DENIED
+    )
     assert exc_info.value.info == None
     assert not requests_to_retry
 
@@ -1685,7 +1688,10 @@ def test_process_futures_failed_precondition_error_status_raises_exception():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.FAILED_PRECONDITION
+    assert (
+        exc_info.value.error_code
+        == subscriber_exceptions.AcknowledgeStatus.FAILED_PRECONDITION
+    )
     assert exc_info.value.info == None
     assert not requests_to_retry
 

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1332,7 +1332,7 @@ def test__on_response_enable_exactly_once():
     # exactly_once should be enabled
     manager._on_response(response)
 
-    assert manager._exactly_once_enabled
+    assert manager._exactly_once_delivery_enabled()
     # new deadline for exactly_once subscriptions should be used
     assert manager.ack_deadline == 60
 

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1576,7 +1576,10 @@ def test_process_futures_permanent_error_raises_exception():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
+    assert (
+        exc_info.value.error_code
+        == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
+    )
     assert not requests_to_retry
 
 
@@ -1656,7 +1659,10 @@ def test_process_futures_mixed_success_and_failure_acks():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future1.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
+    assert (
+        exc_info.value.error_code
+        == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
+    )
     # message with ack_id 'ackid2' is to be retried
     assert requests_to_retry[0].ack_id == "ackid2"
     assert not requests_to_retry[0].future.done()
@@ -1686,7 +1692,10 @@ def test_process_futures_mixed_success_and_failure_modacks():
     assert requests_completed[0].ack_id == "ackid1"
     with pytest.raises(subscriber_exceptions.AcknowledgeError) as exc_info:
         future1.result()
-    assert exc_info.value.error_code == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
+    assert (
+        exc_info.value.error_code
+        == subscriber_exceptions.AcknowledgeStatus.INVALID_ACK_ID
+    )
     # message with ack_id 'ackid2' is to be retried
     assert requests_to_retry[0].ack_id == "ackid2"
     assert not requests_to_retry[0].future.done()

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1668,7 +1668,7 @@ def test_process_futures_permission_denied_error_status_raises_exception():
         exc_info.value.error_code
         == subscriber_exceptions.AcknowledgeStatus.PERMISSION_DENIED
     )
-    assert exc_info.value.info == None
+    assert exc_info.value.info is None
     assert not requests_to_retry
 
 
@@ -1692,7 +1692,7 @@ def test_process_futures_failed_precondition_error_status_raises_exception():
         exc_info.value.error_code
         == subscriber_exceptions.AcknowledgeStatus.FAILED_PRECONDITION
     )
-    assert exc_info.value.info == None
+    assert exc_info.value.info is None
     assert not requests_to_retry
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1514,6 +1514,23 @@ def test_get_ack_errors_no_error_details(from_call):
 
 
 @mock.patch("grpc_status.rpc_status.from_call")
+def test_get_ack_errors_detail_not_error_info(from_call):
+    st = status_pb2.Status()
+    st.code = code_pb2.Code.INTERNAL
+    st.message = "qmsg"
+    # pack a dummy status instead of an ErrorInfo
+    dummy_status = status_pb2.Status()
+    st.details.add().Pack(dummy_status )
+    mock_gprc_call = mock.Mock(spec=grpc.Call)
+    exception = exceptions.InternalServerError(
+        "msg", errors=(), response=mock_gprc_call
+    )
+    from_call.side_effect = None
+    from_call.return_value = st
+    assert not streaming_pull_manager._get_ack_errors(exception)
+
+
+@mock.patch("grpc_status.rpc_status.from_call")
 def test_get_ack_errors_happy_case(from_call):
     st = status_pb2.Status()
     st.code = code_pb2.Code.INTERNAL

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1628,8 +1628,23 @@ def test_process_futures_error_dict_is_none():
     assert not requests_to_retry
 
 
+def test_process_futures_no_errors_has_no_future():
+    # no errors so request should be completed, even with no future
+    future_reqs_dict = {
+        "ackid1": requests.AckRequest(
+            ack_id="ackid1", byte_size=0, time_to_ack=20, ordering_key="", future=None
+        )
+    }
+    errors_dict = {}
+    requests_completed, requests_to_retry = streaming_pull_manager._process_futures(
+        None, future_reqs_dict, errors_dict
+    )
+    assert requests_completed[0].ack_id == "ackid1"
+    assert not requests_to_retry
+
+
 def test_process_futures_no_errors():
-    # no errors so request should be completed
+    # no errors so request and its future should be completed
     future = futures.Future()
     future_reqs_dict = {
         "ackid1": requests.AckRequest(

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -205,7 +205,7 @@ def test_context_manager_raises_if_closed(creds):
     expetect_msg = r"(?i).*closed.*cannot.*context manager.*"
     with pytest.raises(RuntimeError, match=expetect_msg):
         with client:
-            pass
+            pass  # pragma: NO COVER
 
 
 def test_api_property_deprecated(creds):


### PR DESCRIPTION
* Add new field to SubscriptionProperties and modify the GAPIC layer with just this one change. This change will come from the auto-GAPIC generated code once the proto change is public.
* Add async ack/modack/nack methods to the Message class. Exactly-once users have to use this to get the status of ack/modack/nack requests. The futures returned by these methods may be completed by the AcknowledgeError exception (with detailed AcknowledgeStatus status code) or a success AcknowledgeStatus code. These futures are of a new type, one used only on the subscriber-side for propagating exactly-once errors. This future mirrors the publishing-side future that already exists. The futures are completed immediately if exactly-once delivery is not enabled, upon successful ack/modack completion, and when errors/exceptions occur.
* Split unary ack/modack methods into two in the subscriber manager. Some repeated code but it's simpler this way.
* Keep track of whether exactly-once is enabled for a subscription by looking at the subscription's SubscriptionProperties, returned in the streaming response.
* Set the minimum ack deadline to 60 secs if exactly-once is known to be turned on. This deadline is used by the leaser.
* Add new min-lease-extension parameter. If the user sets this, it overrides the auto-set param based on whether exactly-once is enabled or not.
* Retry unary ack/modacks if we get errors in the GRPC call's ErrorInfo (no retry delays as of yet since the server will eventually fail them if the ack expires). This is done in the dispatcher, which retries only the acks/modacks that have failed temporarily. Permanent failures are surfaced to the user as future exceptions. These retries use an exponential backoff with a max of 10 min, which is sufficient since the server allows ack/modacks for 10 mins max. These retries are triggered on a new thread to prevent the dispatcher thread from being blocked by retry-wait sleeps.
* Retry lease modacks, both immediately upon receipt of messages and also in the background. If retries fail or if permanent errors arise, we log the errors but don't otherwise disrupt user code.
* Send a new ack deadline via stream_ack_deadline_seconds whenever the exactly_once setting for a stream changes.
* Add tests ensuring 100% coverage
* Usage sample for this feature added at https://github.com/googleapis/python-pubsub/pull/588