### PR TITLE
process: add mypy session for samples

### DIFF
--- a/google/cloud/pubsub_v1/publisher/futures.py
+++ b/google/cloud/pubsub_v1/publisher/futures.py
@@ -69,7 +69,7 @@ class Future(futures.Future):
     def add_done_callback(
         self, callback: Callable[["pubsub_v1.publisher.futures.Future"], Any]
     ) -> None:
-        """Attache a callable that will be called when the future finishes.
+        """Attach a callable that will be called when the future finishes.
 
         Args:
             callback:

--- a/google/cloud/pubsub_v1/publisher/futures.py
+++ b/google/cloud/pubsub_v1/publisher/futures.py
@@ -14,9 +14,13 @@
 
 from __future__ import absolute_import
 
-from typing import Union
+import typing
+from typing import Any, Callable, Union
 
 from google.cloud.pubsub_v1 import futures
+
+if typing.TYPE_CHECKING:  # pragma: NO COVER
+    from google.cloud import pubsub_v1
 
 
 class Future(futures.Future):
@@ -60,3 +64,20 @@ class Future(futures.Future):
                 call execution.
         """
         return super().result(timeout=timeout)
+
+    # This exists to make the type checkers happy.
+    def add_done_callback(
+        self, callback: Callable[["pubsub_v1.publisher.futures.Future"], Any]
+    ) -> None:
+        """Attache a callable that will be called when the future finishes.
+
+        Args:
+            callback:
+                A callable that will be called with this future as its only
+                argument when the future completes or is cancelled. The callable
+                will always be called by a thread in the same process in which
+                it was added. If the future has already completed or been
+                cancelled then the callable will be called immediately. These
+                callables are called in the order that they were added.
+        """
+        return super().add_done_callback(callback)  # type: ignore

--- a/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/google/cloud/pubsub_v1/subscriber/futures.py
@@ -52,19 +52,27 @@ class StreamingPullFuture(futures.Future):
         else:
             self.set_exception(result)
 
-    def cancel(self):
+    def cancel(self) -> bool:
         """Stops pulling messages and shutdowns the background thread consuming
         messages.
+
+        The method always returns ``True``, as the shutdown is always initiated.
+        However, if the background stream is already being shut down or the shutdown
+        has completed, this method is a no-op.
 
         .. versionchanged:: 2.4.1
            The method does not block anymore, it just triggers the shutdown and returns
            immediately. To block until the background stream is terminated, call
            :meth:`result()` after cancelling the future.
+
+        .. versionchanged:: 2.10.0
+           The method always returns ``True`` instead of ``None``.
         """
         # NOTE: We circumvent the base future's self._state to track the cancellation
         # state, as this state has different meaning with streaming pull futures.
         self.__cancelled = True
-        return self.__manager.close()
+        self.__manager.close()
+        return True
 
     def cancelled(self) -> bool:
         """

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ nox.options.sessions = [
     "lint_setup_py",
     "blacken",
     "mypy",
+    "mypy_samples",
     "pytype",
     "docs",
 ]
@@ -76,6 +77,28 @@ def pytype(session):
     session.install("-e", ".[all]")
     session.install(PYTYPE_VERSION)
     session.run("pytype")
+
+
+@nox.session(python=DEFAULT_PYTHON_VERSION)
+def mypy_samples(session):
+    """Run type checks with mypy."""
+
+    session.install("-e", ".[all]")
+
+    session.install("pytest")
+    session.install(MYPY_VERSION)
+
+    # Just install the type info directly, since "mypy --install-types" might
+    # require an additional pass.
+    session.install("types-mock", "types-protobuf", "types-setuptools")
+
+    session.run(
+        "mypy",
+        "--config-file",
+        str(CURRENT_DIRECTORY / "samples" / "snippets" / "mypy.ini"),
+        "--no-incremental",  # Required by warn-unused-configs from mypy.ini to work
+        "samples/",
+    )
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,6 +65,12 @@ def mypy(session):
     # require an additional pass.
     session.install("types-protobuf", "types-setuptools")
 
+    # Version 2.1.1 of google-api-core version is the first type-checked release.
+    # Version 2.2.0 of google-cloud-core version is the first type-checked release.
+    session.install(
+        "google-api-core[grpc]>=2.1.1", "google-cloud-core>=2.2.0",
+    )
+
     # TODO: Only check the hand-written layer, the generated code does not pass
     # mypy checks yet.
     # https://github.com/googleapis/gapic-generator-python/issues/1092

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,8 +46,8 @@ nox.options.sessions = [
     "lint_setup_py",
     "blacken",
     "mypy",
-    "mypy_samples",
     "pytype",
+    # "mypy_samples",  # TODO: uncomment when the checks pass
     "docs",
 ]
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -447,6 +447,13 @@ s.replace(
         # require an additional pass.
         session.install("types-protobuf", "types-setuptools")
 
+        # Version 2.1.1 of google-api-core version is the first type-checked release.
+        # Version 2.2.0 of google-cloud-core version is the first type-checked release.
+        session.install(
+            "google-api-core[grpc]>=2.1.1",
+            "google-cloud-core>=2.2.0",
+        )
+
         # TODO: Only check the hand-written layer, the generated code does not pass
         # mypy checks yet.
         # https://github.com/googleapis/gapic-generator-python/issues/1092

--- a/owlbot.py
+++ b/owlbot.py
@@ -459,11 +459,13 @@ s.replace(
 # Add mypy_samples nox session.
 # ----------------------------------------------------------------------------
 s.replace(
-    "noxfile.py", r'"mypy",', '\g<0>\n    "mypy_samples",',
+    "noxfile.py",
+    r'"pytype",',
+    '\g<0>\n    # "mypy_samples",  # TODO: uncomment when the checks pass',
 )
 s.replace(
     "noxfile.py",
-    r'session.run\("pytype"\)',
+    r'session\.run\("pytype"\)',
     textwrap.dedent(
         '''    \g<0>
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -454,6 +454,44 @@ s.replace(
     ),
 )
 
+
+# ----------------------------------------------------------------------------
+# Add mypy_samples nox session.
+# ----------------------------------------------------------------------------
+s.replace(
+    "noxfile.py", r'"mypy",', '\g<0>\n    "mypy_samples",',
+)
+s.replace(
+    "noxfile.py",
+    r'session.run\("pytype"\)',
+    textwrap.dedent(
+        '''    \g<0>
+
+
+    @nox.session(python=DEFAULT_PYTHON_VERSION)
+    def mypy_samples(session):
+        """Run type checks with mypy."""
+
+        session.install("-e", ".[all]")
+
+        session.install("pytest")
+        session.install(MYPY_VERSION)
+
+        # Just install the type info directly, since "mypy --install-types" might
+        # require an additional pass.
+        session.install("types-mock", "types-protobuf", "types-setuptools") 
+
+        session.run(
+            "mypy",
+            "--config-file",
+            str(CURRENT_DIRECTORY / "samples" / "snippets" / "mypy.ini"),
+            "--no-incremental",  # Required by warn-unused-configs from mypy.ini to work
+            "samples/",
+        )'''
+    ),
+)
+
+
 # Only consider the hand-written layer when assessing the test coverage.
 s.replace(
     "noxfile.py", "--cov=google", "--cov=google/cloud",

--- a/samples/snippets/iam_test.py
+++ b/samples/snippets/iam_test.py
@@ -78,14 +78,14 @@ def subscription_path(
         pass
 
 
-def test_get_topic_policy(topic_path: str, capsys: CaptureFixture) -> None:
+def test_get_topic_policy(topic_path: str, capsys: CaptureFixture[str]) -> None:
     iam.get_topic_policy(PROJECT_ID, TOPIC_ID)
     out, _ = capsys.readouterr()
     assert topic_path in out
 
 
 def test_get_subscription_policy(
-    subscription_path: str, capsys: CaptureFixture
+    subscription_path: str, capsys: CaptureFixture[str]
 ) -> None:
     iam.get_subscription_policy(PROJECT_ID, SUBSCRIPTION_ID)
     out, _ = capsys.readouterr()
@@ -93,8 +93,8 @@ def test_get_subscription_policy(
 
 
 def test_set_topic_policy(
-    publisher_client: pubsub_v1.PublisherClient, topic_path: str,
-) -> CaptureFixture:
+    publisher_client: pubsub_v1.PublisherClient, topic_path: str
+) -> None:
     iam.set_topic_policy(PROJECT_ID, TOPIC_ID)
     policy = publisher_client.get_iam_policy(request={"resource": topic_path})
     assert "roles/pubsub.publisher" in str(policy)
@@ -110,7 +110,7 @@ def test_set_subscription_policy(
     assert "domain:google.com" in str(policy)
 
 
-def test_check_topic_permissions(topic_path: str, capsys: CaptureFixture) -> None:
+def test_check_topic_permissions(topic_path: str, capsys: CaptureFixture[str]) -> None:
     iam.check_topic_permissions(PROJECT_ID, TOPIC_ID)
     out, _ = capsys.readouterr()
     assert topic_path in out
@@ -118,7 +118,7 @@ def test_check_topic_permissions(topic_path: str, capsys: CaptureFixture) -> Non
 
 
 def test_check_subscription_permissions(
-    subscription_path: str, capsys: CaptureFixture,
+    subscription_path: str, capsys: CaptureFixture[str],
 ) -> None:
     iam.check_subscription_permissions(PROJECT_ID, SUBSCRIPTION_ID)
     out, _ = capsys.readouterr()

--- a/samples/snippets/mypy.ini
+++ b/samples/snippets/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]                                                                                                                                                                                                                                                                                                                                                                                                                                  
+; We require type annotations in all samples.
+strict = True
+exclude = noxfile\.py
+warn_unused_configs = True
+
+[mypy-avro.*,backoff,flaky]
+ignore_missing_imports = True

--- a/samples/snippets/publisher.py
+++ b/samples/snippets/publisher.py
@@ -95,9 +95,9 @@ def publish_messages(project_id: str, topic_id: str) -> None:
     topic_path = publisher.topic_path(project_id, topic_id)
 
     for n in range(1, 10):
-        data = f"Message number {n}"
+        data_str = f"Message number {n}"
         # Data must be a bytestring
-        data = data.encode("utf-8")
+        data = data_str.encode("utf-8")
         # When you publish a message, the client returns a future.
         future = publisher.publish(topic_path, data)
         print(future.result())
@@ -121,9 +121,9 @@ def publish_messages_with_custom_attributes(project_id: str, topic_id: str) -> N
     topic_path = publisher.topic_path(project_id, topic_id)
 
     for n in range(1, 10):
-        data = f"Message number {n}"
+        data_str = f"Message number {n}"
         # Data must be a bytestring
-        data = data.encode("utf-8")
+        data = data_str.encode("utf-8")
         # Add two attributes, origin and username, to the message
         future = publisher.publish(
             topic_path, data, origin="python-sample", username="gcp"
@@ -202,9 +202,9 @@ def publish_messages_with_batch_settings(project_id: str, topic_id: str) -> None
         print(message_id)
 
     for n in range(1, 10):
-        data = f"Message number {n}"
+        data_str = f"Message number {n}"
         # Data must be a bytestring
-        data = data.encode("utf-8")
+        data = data_str.encode("utf-8")
         publish_future = publisher.publish(topic_path, data)
         # Non-blocking. Allow the publisher client to batch multiple messages.
         publish_future.add_done_callback(callback)
@@ -252,9 +252,9 @@ def publish_messages_with_flow_control_settings(project_id: str, topic_id: str) 
     # Publish 1000 messages in quick succession may be constrained by
     # publisher flow control.
     for n in range(1, 1000):
-        data = f"Message number {n}"
+        data_str = f"Message number {n}"
         # Data must be a bytestring
-        data = data.encode("utf-8")
+        data = data_str.encode("utf-8")
         publish_future = publisher.publish(topic_path, data)
         # Non-blocking. Allow the publisher client to batch messages.
         publish_future.add_done_callback(callback)
@@ -298,9 +298,9 @@ def publish_messages_with_retry_settings(project_id: str, topic_id: str) -> None
     topic_path = publisher.topic_path(project_id, topic_id)
 
     for n in range(1, 10):
-        data = f"Message number {n}"
+        data_str = f"Message number {n}"
         # Data must be a bytestring
-        data = data.encode("utf-8")
+        data = data_str.encode("utf-8")
         future = publisher.publish(topic=topic_path, data=data, retry=custom_retry)
         print(future.result())
 

--- a/samples/snippets/quickstart/pub.py
+++ b/samples/snippets/quickstart/pub.py
@@ -33,7 +33,7 @@ def pub(project_id: str, topic_id: str) -> None:
     api_future = client.publish(topic_path, data)
     message_id = api_future.result()
 
-    print(f"Published {data} to {topic_path}: {message_id}")
+    print(f"Published {data.decode()} to {topic_path}: {message_id}")
 
 
 if __name__ == "__main__":

--- a/samples/snippets/quickstart/quickstart_test.py
+++ b/samples/snippets/quickstart/quickstart_test.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os
-from typing import Generator
+from typing import Any, Callable, cast, Iterator, TypeVar
 import uuid
 
 from _pytest.capture import CaptureFixture
@@ -32,19 +32,19 @@ SUBSCRIPTION_ID = "quickstart-sub-test-topic-sub-" + UUID
 
 
 @pytest.fixture(scope="module")
-def publisher_client() -> Generator[pubsub_v1.PublisherClient, None, None]:
+def publisher_client() -> Iterator[pubsub_v1.PublisherClient]:
     yield pubsub_v1.PublisherClient()
 
 
 @pytest.fixture(scope="module")
-def subscriber_client() -> Generator[pubsub_v1.SubscriberClient, None, None]:
+def subscriber_client() -> Iterator[pubsub_v1.SubscriberClient]:
     subscriber_client = pubsub_v1.SubscriberClient()
     yield subscriber_client
     subscriber_client.close()
 
 
 @pytest.fixture(scope="module")
-def topic_path(publisher_client: pubsub_v1.PublisherClient) -> Generator[str, None, None]:
+def topic_path(publisher_client: pubsub_v1.PublisherClient) -> Iterator[str]:
     topic_path = publisher_client.topic_path(PROJECT_ID, TOPIC_ID)
 
     try:
@@ -57,7 +57,9 @@ def topic_path(publisher_client: pubsub_v1.PublisherClient) -> Generator[str, No
 
 
 @pytest.fixture(scope="module")
-def subscription_path(subscriber_client: pubsub_v1.SubscriberClient, topic_path: str) -> Generator[str, None, None]:
+def subscription_path(
+    subscriber_client: pubsub_v1.SubscriberClient, topic_path: str
+) -> Iterator[str]:
     subscription_path = subscriber_client.subscription_path(PROJECT_ID, SUBSCRIPTION_ID)
 
     try:
@@ -72,7 +74,7 @@ def subscription_path(subscriber_client: pubsub_v1.SubscriberClient, topic_path:
     subscriber_client.close()
 
 
-def test_pub(topic_path: str, capsys: CaptureFixture) -> None:
+def test_pub(topic_path: str, capsys: CaptureFixture[str]) -> None:
     import pub
 
     pub.pub(PROJECT_ID, TOPIC_ID)
@@ -82,8 +84,17 @@ def test_pub(topic_path: str, capsys: CaptureFixture) -> None:
     assert "Hello, World!" in out
 
 
-@flaky(max_runs=3, min_passes=1)
-def test_sub(publisher_client: pubsub_v1.PublisherClient, topic_path: str, subscription_path: str, capsys: CaptureFixture) -> None:
+C = TypeVar("C", bound=Callable[..., Any])
+_typed_flaky = cast(Callable[[C], C], flaky(max_runs=3, min_passes=1))
+
+
+@_typed_flaky
+def test_sub(
+    publisher_client: pubsub_v1.PublisherClient,
+    topic_path: str,
+    subscription_path: str,
+    capsys: CaptureFixture[str],
+) -> None:
     publisher_client.publish(topic_path, b"Hello World!")
 
     import sub

--- a/samples/snippets/quickstart/sub.py
+++ b/samples/snippets/quickstart/sub.py
@@ -15,11 +15,12 @@
 # limitations under the License.
 
 import argparse
+from typing import Optional
 
 from google.cloud import pubsub_v1
 
 
-def sub(project_id: str, subscription_id: str, timeout: float = None) -> None:
+def sub(project_id: str, subscription_id: str, timeout: Optional[float] = None) -> None:
     """Receives messages from a Pub/Sub subscription."""
     # Initialize a Subscriber client
     subscriber_client = pubsub_v1.SubscriberClient()

--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,6 +1,2 @@
-# Version 2.1.1 of google-api-core version is the first type-checked release.
-google-api-core[grpc]==2.1.1
-# Version 2.2.0 of google-cloud-core version is the first type-checked release.
-google-cloud-core==2.2.0
 google-cloud-pubsub==2.9.0
 avro==1.11.0

--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,2 +1,6 @@
+# Version 2.1.1 of google-api-core version is the first type-checked release.
+google-api-core[grpc]==2.1.1
+# Version 2.2.0 of google-cloud-core version is the first type-checked release.
+google-cloud-core==2.2.0
 google-cloud-pubsub==2.9.0
 avro==1.11.0

--- a/samples/snippets/schema.py
+++ b/samples/snippets/schema.py
@@ -22,6 +22,7 @@ at https://cloud.google.com/pubsub/docs/schemas.
 """
 
 import argparse
+from typing import Optional
 
 from google.cloud import pubsub_v1
 
@@ -234,10 +235,11 @@ def publish_avro_records(project_id: str, topic_id: str, avsc_file: str) -> None
             encoder = BinaryEncoder(bout)
             writer.write(record, encoder)
             data = bout.getvalue()
-            print(f"Preparing a binary-encoded message:\n{data}")
+            print(f"Preparing a binary-encoded message:\n{data.decode()}")
         elif encoding == Encoding.JSON:
-            data = json.dumps(record).encode("utf-8")
-            print(f"Preparing a JSON-encoded message:\n{data}")
+            data_str = json.dumps(record)
+            print(f"Preparing a JSON-encoded message:\n{data_str}")
+            data = data_str.encode("utf-8")
         else:
             print(f"No encoding specified in {topic_path}. Abort.")
             exit(0)
@@ -258,7 +260,7 @@ def publish_proto_messages(project_id: str, topic_id: str) -> None:
     from google.protobuf.json_format import MessageToJson
     from google.pubsub_v1.types import Encoding
 
-    from utilities import us_states_pb2
+    from utilities import us_states_pb2  # type: ignore
 
     # TODO(developer): Replace these variables before running the sample.
     # project_id = "your-project-id"
@@ -298,7 +300,10 @@ def publish_proto_messages(project_id: str, topic_id: str) -> None:
 
 
 def subscribe_with_avro_schema(
-    project_id: str, subscription_id: str, avsc_file: str, timeout: float = None
+    project_id: str,
+    subscription_id: str,
+    avsc_file: str,
+    timeout: Optional[float] = None,
 ) -> None:
     """Receive and decode messages sent to a topic with an Avro schema."""
     # [START pubsub_subscribe_avro_records]

--- a/samples/snippets/schema_test.py
+++ b/samples/snippets/schema_test.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os
-from typing import Generator
+from typing import Any, Callable, cast, Generator, TypeVar
 import uuid
 
 from _pytest.capture import CaptureFixture
@@ -290,7 +290,11 @@ def test_subscribe_with_proto_schema(
     assert "Received a binary-encoded message" in out
 
 
-@flaky(max_runs=3, min_passes=1)
+C = TypeVar("C", bound=Callable[..., Any])
+typed_flaky = cast(Callable[[C], C], flaky(max_runs=3, min_passes=1))
+
+
+@typed_flaky
 def test_delete_schema(proto_schema: str, capsys: CaptureFixture[str]) -> None:
     schema.delete_schema(PROJECT_ID, PROTO_SCHEMA_ID)
     out, _ = capsys.readouterr()

--- a/samples/snippets/schema_test.py
+++ b/samples/snippets/schema_test.py
@@ -193,7 +193,7 @@ def proto_subscription(
 def test_create_avro_schema(
     schema_client: pubsub_v1.SchemaServiceClient,
     avro_schema: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     try:
         schema_client.delete_schema(request={"name": avro_schema})
@@ -210,7 +210,7 @@ def test_create_avro_schema(
 def test_create_proto_schema(
     schema_client: pubsub_v1.SchemaServiceClient,
     proto_schema: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     try:
         schema_client.delete_schema(request={"name": proto_schema})
@@ -224,20 +224,22 @@ def test_create_proto_schema(
     assert f"{proto_schema}" in out
 
 
-def test_get_schema(avro_schema: str, capsys: CaptureFixture) -> None:
+def test_get_schema(avro_schema: str, capsys: CaptureFixture[str]) -> None:
     schema.get_schema(PROJECT_ID, AVRO_SCHEMA_ID)
     out, _ = capsys.readouterr()
     assert "Got a schema" in out
     assert f"{avro_schema}" in out
 
 
-def test_list_schemas(capsys: CaptureFixture) -> None:
+def test_list_schemas(capsys: CaptureFixture[str]) -> None:
     schema.list_schemas(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "Listed schemas." in out
 
 
-def test_create_topic_with_schema(avro_schema: str, capsys: CaptureFixture) -> None:
+def test_create_topic_with_schema(
+    avro_schema: str, capsys: CaptureFixture[str]
+) -> None:
     schema.create_topic_with_schema(PROJECT_ID, AVRO_TOPIC_ID, AVRO_SCHEMA_ID, "BINARY")
     out, _ = capsys.readouterr()
     assert "Created a topic" in out
@@ -247,7 +249,7 @@ def test_create_topic_with_schema(avro_schema: str, capsys: CaptureFixture) -> N
 
 
 def test_publish_avro_records(
-    avro_schema: str, avro_topic: str, capsys: CaptureFixture
+    avro_schema: str, avro_topic: str, capsys: CaptureFixture[str]
 ) -> None:
     schema.publish_avro_records(PROJECT_ID, AVRO_TOPIC_ID, AVSC_FILE)
     out, _ = capsys.readouterr()
@@ -256,7 +258,10 @@ def test_publish_avro_records(
 
 
 def test_subscribe_with_avro_schema(
-    avro_schema: str, avro_topic: str, avro_subscription: str, capsys: CaptureFixture
+    avro_schema: str,
+    avro_topic: str,
+    avro_subscription: str,
+    capsys: CaptureFixture[str],
 ) -> None:
     schema.publish_avro_records(PROJECT_ID, AVRO_TOPIC_ID, AVSC_FILE)
 
@@ -265,7 +270,7 @@ def test_subscribe_with_avro_schema(
     assert "Received a binary-encoded message:" in out
 
 
-def test_publish_proto_records(proto_topic: str, capsys: CaptureFixture) -> None:
+def test_publish_proto_records(proto_topic: str, capsys: CaptureFixture[str]) -> None:
     schema.publish_proto_messages(PROJECT_ID, PROTO_TOPIC_ID)
     out, _ = capsys.readouterr()
     assert "Preparing a binary-encoded message" in out
@@ -273,7 +278,10 @@ def test_publish_proto_records(proto_topic: str, capsys: CaptureFixture) -> None
 
 
 def test_subscribe_with_proto_schema(
-    proto_schema: str, proto_topic: str, proto_subscription: str, capsys: CaptureFixture
+    proto_schema: str,
+    proto_topic: str,
+    proto_subscription: str,
+    capsys: CaptureFixture[str],
 ) -> None:
     schema.publish_proto_messages(PROJECT_ID, PROTO_TOPIC_ID)
 
@@ -283,7 +291,7 @@ def test_subscribe_with_proto_schema(
 
 
 @flaky(max_runs=3, min_passes=1)
-def test_delete_schema(proto_schema: str, capsys: CaptureFixture) -> None:
+def test_delete_schema(proto_schema: str, capsys: CaptureFixture[str]) -> None:
     schema.delete_schema(PROJECT_ID, PROTO_SCHEMA_ID)
     out, _ = capsys.readouterr()
     assert "Deleted a schema" in out

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -450,7 +450,7 @@ def receive_messages_with_custom_attributes(
     subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message: pubsub_v1.subscriber.message.Message) -> None:
-        print(f"Received {message.data}.")
+        print(f"Received {message.data!r}.")
         if message.attributes:
             print("Attributes:")
             for key in message.attributes:
@@ -491,7 +491,7 @@ def receive_messages_with_flow_control(
     subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message: pubsub_v1.subscriber.message.Message) -> None:
-        print(f"Received {message.data}.")
+        print(f"Received {message.data!r}.")
         message.ack()
 
     # Limit the subscriber to only have ten outstanding messages at a time.
@@ -533,10 +533,10 @@ def receive_messages_with_blocking_shutdown(
     subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message: pubsub_v1.subscriber.message.Message) -> None:
-        print(f"Received {message.data}.")
+        print(f"Received {message.data!r}.")
         time.sleep(timeout + 3.0)  # Pocess longer than streaming pull future timeout.
         message.ack()
-        print(f"Done processing the message {message.data}.")
+        print(f"Done processing the message {message.data!r}.")
 
     streaming_pull_future = subscriber.subscribe(
         subscription_path, callback=callback, await_callbacks_on_shutdown=True,

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -22,6 +22,11 @@ at https://cloud.google.com/pubsub/docs.
 """
 
 import argparse
+import typing
+from typing import Optional
+
+if typing.TYPE_CHECKING:
+    from google.pubsub_v1 import types as gapic_types
 
 
 def list_subscriptions_in_topic(project_id: str, topic_id: str) -> None:
@@ -278,7 +283,7 @@ def update_subscription_with_dead_letter_policy(
     subscription_id: str,
     dead_letter_topic_id: str,
     max_delivery_attempts: int = 5,
-) -> None:
+) -> "gapic_types.Subscription":
     """Update a subscription's dead letter policy."""
     # [START pubsub_dead_letter_update_subscription]
     from google.cloud import pubsub_v1
@@ -327,8 +332,11 @@ def update_subscription_with_dead_letter_policy(
     )
 
     with subscriber:
-        subscription_after_update = subscriber.update_subscription(
-            request={"subscription": subscription, "update_mask": update_mask}
+        subscription_after_update = typing.cast(
+            "gapic_types.Subscription",
+            subscriber.update_subscription(
+                request={"subscription": subscription, "update_mask": update_mask}
+            ),
         )
 
     print(f"After the update: {subscription_after_update}.")
@@ -338,7 +346,7 @@ def update_subscription_with_dead_letter_policy(
 
 def remove_dead_letter_policy(
     project_id: str, topic_id: str, subscription_id: str
-) -> None:
+) -> "gapic_types.Subscription":
     """Remove dead letter policy from a subscription."""
     # [START pubsub_dead_letter_remove]
     from google.cloud import pubsub_v1
@@ -372,8 +380,11 @@ def remove_dead_letter_policy(
     )
 
     with subscriber:
-        subscription_after_update = subscriber.update_subscription(
-            request={"subscription": subscription, "update_mask": update_mask}
+        subscription_after_update = typing.cast(
+            "gapic_types.Subscription",
+            subscriber.update_subscription(
+                request={"subscription": subscription, "update_mask": update_mask}
+            ),
         )
 
     print(f"After removing the policy: {subscription_after_update}.")
@@ -382,7 +393,7 @@ def remove_dead_letter_policy(
 
 
 def receive_messages(
-    project_id: str, subscription_id: str, timeout: float = None
+    project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
     """Receives messages from a pull subscription."""
     # [START pubsub_subscriber_async_pull]
@@ -422,7 +433,7 @@ def receive_messages(
 
 
 def receive_messages_with_custom_attributes(
-    project_id: str, subscription_id: str, timeout: float = None
+    project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
     """Receives messages from a pull subscription."""
     # [START pubsub_subscriber_async_pull_custom_attributes]
@@ -463,7 +474,7 @@ def receive_messages_with_custom_attributes(
 
 
 def receive_messages_with_flow_control(
-    project_id: str, subscription_id: str, timeout: float = None
+    project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
     """Receives messages from a pull subscription with flow control."""
     # [START pubsub_subscriber_flow_settings]
@@ -665,7 +676,7 @@ def synchronous_pull_with_lease_management(
 
 
 def listen_for_errors(
-    project_id: str, subscription_id: str, timeout: float = None
+    project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
     """Receives messages and catches errors from a pull subscription."""
     # [START pubsub_subscriber_error_listener]
@@ -703,7 +714,7 @@ def listen_for_errors(
 
 
 def receive_messages_with_delivery_attempts(
-    project_id: str, subscription_id: str, timeout: float = None
+    project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
     # [START pubsub_dead_letter_delivery_attempt]
     from concurrent.futures import TimeoutError

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -205,7 +205,7 @@ def _publish_messages(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     message_num: int = 5,
-    **attrs: str,
+    **attrs: Any,
 ) -> None:
     for n in range(message_num):
         data = f"message {n}".encode("utf-8")

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -16,7 +16,7 @@ import os
 import re
 import sys
 import time
-from typing import Generator
+from typing import Any, Callable, cast, Generator, TypeVar
 import uuid
 
 from _pytest.capture import CaptureFixture
@@ -43,6 +43,10 @@ ENDPOINT = f"https://{PROJECT_ID}.appspot.com/push"
 NEW_ENDPOINT = f"https://{PROJECT_ID}.appspot.com/push2"
 DEFAULT_MAX_DELIVERY_ATTEMPTS = 5
 UPDATED_MAX_DELIVERY_ATTEMPTS = 20
+
+C = TypeVar("C", bound=Callable[..., Any])
+
+typed_flaky = cast(Callable[[C], C], flaky(max_runs=3, min_passes=1))
 
 
 @pytest.fixture(scope="module")
@@ -126,7 +130,11 @@ def subscription_sync(
 
     yield subscription.name
 
-    @backoff.on_exception(backoff.expo, Unknown, max_time=300)
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
+    )
+
+    @typed_backoff
     def delete_subscription() -> None:
         try:
             subscriber_client.delete_subscription(
@@ -197,7 +205,7 @@ def _publish_messages(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     message_num: int = 5,
-    **attrs: dict,
+    **attrs: str,
 ) -> None:
     for n in range(message_num):
         data = f"message {n}".encode("utf-8")
@@ -205,8 +213,13 @@ def _publish_messages(
         publish_future.result()
 
 
-def test_list_in_topic(subscription_admin: str, capsys: CaptureFixture) -> None:
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=60)
+def test_list_in_topic(subscription_admin: str, capsys: CaptureFixture[str]) -> None:
+    typed_backoff = cast(
+        Callable[[C], C],
+        backoff.on_exception(backoff.expo, AssertionError, max_time=60),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         subscriber.list_subscriptions_in_topic(PROJECT_ID, TOPIC)
         out, _ = capsys.readouterr()
@@ -215,8 +228,13 @@ def test_list_in_topic(subscription_admin: str, capsys: CaptureFixture) -> None:
     eventually_consistent_test()
 
 
-def test_list_in_project(subscription_admin: str, capsys: CaptureFixture) -> None:
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=60)
+def test_list_in_project(subscription_admin: str, capsys: CaptureFixture[str]) -> None:
+    typed_backoff = cast(
+        Callable[[C], C],
+        backoff.on_exception(backoff.expo, AssertionError, max_time=60),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         subscriber.list_subscriptions_in_project(PROJECT_ID)
         out, _ = capsys.readouterr()
@@ -228,7 +246,7 @@ def test_list_in_project(subscription_admin: str, capsys: CaptureFixture) -> Non
 def test_create_subscription(
     subscriber_client: pubsub_v1.SubscriberClient,
     subscription_admin: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     subscription_path = subscriber_client.subscription_path(
         PROJECT_ID, SUBSCRIPTION_ADMIN
@@ -251,7 +269,7 @@ def test_create_subscription_with_dead_letter_policy(
     subscriber_client: pubsub_v1.SubscriberClient,
     subscription_dlq: str,
     dead_letter_topic: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     try:
         subscriber_client.delete_subscription(
@@ -270,18 +288,23 @@ def test_create_subscription_with_dead_letter_policy(
     assert f"After {DEFAULT_MAX_DELIVERY_ATTEMPTS} delivery attempts." in out
 
 
-@flaky(max_runs=3, min_passes=1)
+@typed_flaky
 def test_receive_with_delivery_attempts(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     dead_letter_topic: str,
     subscription_dlq: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
+
+    typed_backoff = cast(
+        Callable[[C], C],
+        backoff.on_exception(backoff.expo, (Unknown, NotFound), max_time=120),
+    )
 
     # The dlq subscription raises 404 before it's ready.
     # We keep retrying up to 10 minutes for mitigating the flakiness.
-    @backoff.on_exception(backoff.expo, (Unknown, NotFound), max_time=120)
+    @typed_backoff
     def run_sample() -> None:
         _publish_messages(publisher_client, topic)
 
@@ -296,14 +319,19 @@ def test_receive_with_delivery_attempts(
     assert "With delivery attempts: " in out
 
 
-@flaky(max_runs=3, min_passes=1)
+@typed_flaky
 def test_update_dead_letter_policy(
-    subscription_dlq: str, dead_letter_topic: str, capsys: CaptureFixture
+    subscription_dlq: str, dead_letter_topic: str, capsys: CaptureFixture[str]
 ) -> None:
+
+    typed_backoff = cast(
+        Callable[[C], C],
+        backoff.on_exception(backoff.expo, (Unknown, InternalServerError), max_time=60),
+    )
 
     # We saw internal server error that suggests to retry.
 
-    @backoff.on_exception(backoff.expo, (Unknown, InternalServerError), max_time=60)
+    @typed_backoff
     def run_sample() -> None:
         subscriber.update_subscription_with_dead_letter_policy(
             PROJECT_ID,
@@ -321,9 +349,9 @@ def test_update_dead_letter_policy(
     assert f"max_delivery_attempts: {UPDATED_MAX_DELIVERY_ATTEMPTS}" in out
 
 
-@flaky(max_runs=3, min_passes=1)
+@typed_flaky
 def test_remove_dead_letter_policy(
-    subscription_dlq: str, capsys: CaptureFixture
+    subscription_dlq: str, capsys: CaptureFixture[str]
 ) -> None:
     subscription_after_update = subscriber.remove_dead_letter_policy(
         PROJECT_ID, TOPIC, SUBSCRIPTION_DLQ
@@ -337,7 +365,7 @@ def test_remove_dead_letter_policy(
 def test_create_subscription_with_ordering(
     subscriber_client: pubsub_v1.SubscriberClient,
     subscription_admin: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     subscription_path = subscriber_client.subscription_path(
         PROJECT_ID, SUBSCRIPTION_ADMIN
@@ -360,10 +388,14 @@ def test_create_subscription_with_ordering(
 def test_create_push_subscription(
     subscriber_client: pubsub_v1.SubscriberClient,
     subscription_admin: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    )
+
     # The scope of `subscription_path` is limited to this function.
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=60)
+    @typed_backoff
     def eventually_consistent_test() -> None:
         subscription_path = subscriber_client.subscription_path(
             PROJECT_ID, SUBSCRIPTION_ADMIN
@@ -375,7 +407,9 @@ def test_create_push_subscription(
         except NotFound:
             pass
 
-        subscriber.create_push_subscription(PROJECT_ID, TOPIC, SUBSCRIPTION_ADMIN, ENDPOINT)
+        subscriber.create_push_subscription(
+            PROJECT_ID, TOPIC, SUBSCRIPTION_ADMIN, ENDPOINT
+        )
 
         out, _ = capsys.readouterr()
         assert f"{subscription_admin}" in out
@@ -384,10 +418,14 @@ def test_create_push_subscription(
 
 
 def test_update_push_suscription(
-    subscription_admin: str,
-    capsys: CaptureFixture,
+    subscription_admin: str, capsys: CaptureFixture[str],
 ) -> None:
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=60)
+
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         subscriber.update_push_subscription(
             PROJECT_ID, TOPIC, SUBSCRIPTION_ADMIN, NEW_ENDPOINT
@@ -405,7 +443,11 @@ def test_delete_subscription(
 ) -> None:
     subscriber.delete_subscription(PROJECT_ID, SUBSCRIPTION_ADMIN)
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=60)
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         with pytest.raises(Exception):
             subscriber_client.get_subscription(
@@ -419,10 +461,14 @@ def test_receive(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     subscription_async: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
 
-    @backoff.on_exception(backoff.expo, Unknown, max_time=60)
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         _publish_messages(publisher_client, topic)
 
@@ -440,10 +486,14 @@ def test_receive_with_custom_attributes(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     subscription_async: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
 
-    @backoff.on_exception(backoff.expo, Unknown, max_time=60)
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         _publish_messages(publisher_client, topic, origin="python-sample")
 
@@ -464,10 +514,14 @@ def test_receive_with_flow_control(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     subscription_async: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
 
-    @backoff.on_exception(backoff.expo, Unknown, max_time=300)
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         _publish_messages(publisher_client, topic)
 
@@ -485,7 +539,7 @@ def test_receive_with_blocking_shutdown(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     subscription_async: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
 
     _received = re.compile(r".*received.*message.*", flags=re.IGNORECASE)
@@ -493,7 +547,11 @@ def test_receive_with_blocking_shutdown(
     _canceled = re.compile(r".*streaming pull future canceled.*", flags=re.IGNORECASE)
     _shut_down = re.compile(r".*done waiting.*stream shutdown.*", flags=re.IGNORECASE)
 
-    @backoff.on_exception(backoff.expo, Unknown, max_time=300)
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         _publish_messages(publisher_client, topic, message_num=3)
 
@@ -505,24 +563,14 @@ def test_receive_with_blocking_shutdown(
         out_lines = out.splitlines()
 
         msg_received_lines = [
-            i
-            for i, line in enumerate(out_lines)
-            if _received.search(line)
+            i for i, line in enumerate(out_lines) if _received.search(line)
         ]
-        msg_done_lines = [
-            i
-            for i, line in enumerate(out_lines)
-            if _done.search(line)
-        ]
+        msg_done_lines = [i for i, line in enumerate(out_lines) if _done.search(line)]
         stream_canceled_lines = [
-            i
-            for i, line in enumerate(out_lines)
-            if _canceled.search(line)
+            i for i, line in enumerate(out_lines) if _canceled.search(line)
         ]
         shutdown_done_waiting_lines = [
-            i
-            for i, line in enumerate(out_lines)
-            if _shut_down.search(line)
+            i for i, line in enumerate(out_lines) if _shut_down.search(line)
         ]
 
         try:
@@ -554,10 +602,14 @@ def test_listen_for_errors(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     subscription_async: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
 
-    @backoff.on_exception(backoff.expo, Unknown, max_time=60)
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    )
+
+    @typed_backoff
     def eventually_consistent_test() -> None:
         _publish_messages(publisher_client, topic)
 
@@ -574,7 +626,7 @@ def test_receive_synchronously(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     subscription_sync: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
     _publish_messages(publisher_client, topic)
 
@@ -586,14 +638,19 @@ def test_receive_synchronously(
     assert f"{subscription_sync}" in out
 
 
-@flaky(max_runs=3, min_passes=1)
+@typed_flaky
 def test_receive_synchronously_with_lease(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,
     subscription_sync: str,
-    capsys: CaptureFixture,
+    capsys: CaptureFixture[str],
 ) -> None:
-    @backoff.on_exception(backoff.expo, Unknown, max_time=300)
+
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
+    )
+
+    @typed_backoff
     def run_sample() -> None:
         _publish_messages(publisher_client, topic, message_num=10)
         # Pausing 10s to allow the subscriber to establish the connection


### PR DESCRIPTION
Towards googleapis/google-cloud-python#15652.

This PR adds the `mypy` session for samples and cleans up their type annotations.

However, the PR does not address the errors caused by `mypy` not realizing that a lot of methods from the generated client are dynamically injected into the hand written class. It also does not deal with a few missing annotations in `google-api-core` (e.g. `retry.Retry`).

Additional thing to consider is that the client classes that the end users use now have many more methods on them that were previously stored on their `client.api` attribute (and the .`api` attribute has been removed). Caution is needed here.