### PR TITLE
build: upgrade pip in samples build script

### DIFF
--- a/.kokoro/presubmit-against-pubsublite-samples.sh
+++ b/.kokoro/presubmit-against-pubsublite-samples.sh
@@ -79,7 +79,7 @@ for file in python-pubsublite/samples/**/requirements.txt; do
     python3.6 -m venv py-3.6
     source py-3.6/bin/activate
     # Install python-pubsublite samples tests requirements.
-    python -m pip install -r requirements.txt -q
+    python -m pip install --upgrade google-cloud-pubsublite==1.3.0 -q
     python -m pip install -r requirements-test.txt -q
     # Install python-pubsub from source.
     python -m pip install -e "$ROOT" -q

--- a/.kokoro/presubmit-against-pubsublite-samples.sh
+++ b/.kokoro/presubmit-against-pubsublite-samples.sh
@@ -79,7 +79,7 @@ for file in python-pubsublite/samples/**/requirements.txt; do
     python3.6 -m venv py-3.6
     source py-3.6/bin/activate
     # Install python-pubsublite samples tests requirements.
-    python -m pip install --upgrade google-cloud-pubsublite==1.3.0 -q
+    python -m pip install --upgrade google-cloud-pubsublite==1.2.0 -q
     python -m pip install -r requirements-test.txt -q
     # Install python-pubsub from source.
     python -m pip install -e "$ROOT" -q

--- a/.kokoro/presubmit-against-pubsublite-samples.sh
+++ b/.kokoro/presubmit-against-pubsublite-samples.sh
@@ -79,7 +79,8 @@ for file in python-pubsublite/samples/**/requirements.txt; do
     python3.6 -m venv py-3.6
     source py-3.6/bin/activate
     # Install python-pubsublite samples tests requirements.
-    python -m pip install --upgrade google-cloud-pubsublite==1.2.0 -q
+    python -m pip install --upgrade pip
+    python -m pip install -r requirements.txt -q
     python -m pip install -r requirements-test.txt -q
     # Install python-pubsub from source.
     python -m pip install -e "$ROOT" -q


### PR DESCRIPTION
Test to see if google-cloud-pubsublite==1.3.0 passes tests. 

Both 1.2 and 1.3 failed. Upgrading `pip` worked.

`You are using pip version 18.1, however version 21.3.1 is available.` pip==18.1 was not enough.