### PR TITLE
fix(deps): move libcst to extras

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,10 +24,10 @@ The 2.0.0 release requires Python 3.6+.
 Almost all methods that send requests to the backend expect request objects. We
 provide a script that will convert most common use cases.
 
-* Install the library
+* Install the library with the `libcst` extra.
 
 ```py
-python3 -m pip install google-cloud-pubsub
+python3 -m pip install google-cloud-pubsub[libcst]
 ```
 
 * The script `fixup_pubsub_v1_keywords.py` is shipped with the library. It expects

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,10 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
-    "libcst >= 0.3.10",
     "proto-plus >= 1.7.1",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
-extras = {}
+extras = {"libcst": "libcst >= 0.3.10"}
 
 
 # Setup boilerplate below this line.


### PR DESCRIPTION
`libcst` is only needed to run the fixup script.
