### PR TITLE
samples: sample for receiving messages with exactly-once delivery enabled

### DIFF
--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -584,7 +584,7 @@ def receive_messages_with_exactly_once_delivery_enabled(
     project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
     """Receives messages from a pull subscription with exactly-once delivery enabled."""
-    # [START pubsub_subscriber_exactly_once_delivery]
+    # [START pubsub_subscriber_exactly_once]
     from concurrent.futures import TimeoutError
     from google.cloud import pubsub_v1
     from google.cloud.pubsub_v1.subscriber import sub_exceptions
@@ -603,6 +603,10 @@ def receive_messages_with_exactly_once_delivery_enabled(
     def callback(message: pubsub_v1.subscriber.message.Message) -> None:
         print(f"Received {message}.")
 
+        # Use `ack_with_response()` instead of `ack()` to get a future that tracks
+        # the result of the acknowledge call. When exactly-once delivery is enabled
+        # on the subscription, the message is guaranteed to not be delivered again
+        # if the ack future succeeds.
         ack_future = message.ack_with_response()
 
         try:
@@ -628,7 +632,7 @@ def receive_messages_with_exactly_once_delivery_enabled(
         except TimeoutError:
             streaming_pull_future.cancel()  # Trigger the shutdown.
             streaming_pull_future.result()  # Block until the shutdown is complete.
-    # [END pubsub_subscriber_exactly_once_delivery]
+    # [END pubsub_subscriber_exactly_once]
 
 
 def synchronous_pull(project_id: str, subscription_id: str) -> None:

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -580,7 +580,7 @@ def receive_messages_with_blocking_shutdown(
     # [END pubsub_subscriber_blocking_shutdown]
 
 
-def receive_messages_with_exactly_once_subscribe(
+def receive_messages_with_exactly_once_delivery_enabled(
     project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
     """Receives messages from a pull subscription with exactly-once delivery enabled."""
@@ -936,6 +936,15 @@ if __name__ == "__main__":  # noqa
         "timeout", default=None, type=float, nargs="?"
     )
 
+    receive_messages_with_exactly_once_delivery_enabled_parser = subparsers.add_parser(
+        "receive-messages-with-exactly-once-delivery-enabled",
+        help=receive_messages_with_exactly_once_delivery_enabled.__doc__,
+    )
+    receive_messages_with_exactly_once_delivery_enabled_parser.add_argument("subscription_id")
+    receive_messages_with_exactly_once_delivery_enabled_parser.add_argument(
+        "timeout", default=None, type=float, nargs="?"
+    )
+
     synchronous_pull_parser = subparsers.add_parser(
         "receive-synchronously", help=synchronous_pull.__doc__
     )
@@ -1020,6 +1029,10 @@ if __name__ == "__main__":  # noqa
         )
     elif args.command == "receive-blocking-shutdown":
         receive_messages_with_blocking_shutdown(
+            args.project_id, args.subscription_id, args.timeout
+        )
+    elif args.command == "receive-messages-with-exactly-once-delivery-enabled":
+        receive_messages_with_exactly_once_delivery_enabled(
             args.project_id, args.subscription_id, args.timeout
         )
     elif args.command == "receive-synchronously":

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -616,12 +616,7 @@ def receive_messages_with_exactly_once_delivery_enabled(
                 f"Ack for message {message.message_id} failed with error: {e.error_code}"
             )
 
-    # Set a high `min_duration_per_lease_extension` to ensure the subscriber
-    # has plenty of time to process the message.
-    flow_control = pubsub_v1.types.FlowControl(min_duration_per_lease_extension=120)
-    streaming_pull_future = subscriber.subscribe(
-        subscription_path, callback=callback, flow_control=flow_control
-    )
+    streaming_pull_future = subscriber.subscribe(subscription_path, callback=callback)
     print(f"Listening for messages on {subscription_path}..\n")
 
     # Wrap subscriber in a 'with' block to automatically call close() when done.
@@ -941,7 +936,9 @@ if __name__ == "__main__":  # noqa
         "receive-messages-with-exactly-once-delivery-enabled",
         help=receive_messages_with_exactly_once_delivery_enabled.__doc__,
     )
-    receive_messages_with_exactly_once_delivery_enabled_parser.add_argument("subscription_id")
+    receive_messages_with_exactly_once_delivery_enabled_parser.add_argument(
+        "subscription_id"
+    )
     receive_messages_with_exactly_once_delivery_enabled_parser.add_argument(
         "timeout", default=None, type=float, nargs="?"
     )

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -587,7 +587,7 @@ def receive_messages_with_exactly_once_delivery_enabled(
     # [START pubsub_subscriber_exactly_once]
     from concurrent.futures import TimeoutError
     from google.cloud import pubsub_v1
-    from google.cloud.pubsub_v1.subscriber import sub_exceptions
+    from google.cloud.pubsub_v1.subscriber import exceptions as sub_exceptions
 
     # TODO(developer)
     # project_id = "your-project-id"

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -607,7 +607,9 @@ def receive_messages_with_exactly_once_delivery_enabled(
 
         try:
             # Block on result of acknowledge call.
-            ack_future.result()
+            # When `timeout` is not set, result() will block indefinitely,
+            # unless an exception is encountered first.
+            ack_future.result(timeout=timeout)
             print(f"Ack for message {message.message_id} successful.")
         except sub_exceptions.AcknowledgeError as e:
             print(
@@ -617,7 +619,6 @@ def receive_messages_with_exactly_once_delivery_enabled(
     # Set a high `min_duration_per_lease_extension` to ensure the subscriber
     # has plenty of time to process the message.
     flow_control = pubsub_v1.types.FlowControl(min_duration_per_lease_extension=120)
-
     streaming_pull_future = subscriber.subscribe(
         subscription_path, callback=callback, flow_control=flow_control
     )

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -624,6 +624,32 @@ def test_receive_with_blocking_shutdown(
     eventually_consistent_test()
 
 
+def test_receive_messages_with_exactly_once_delivery_enabled(
+    publisher_client: pubsub_v1.PublisherClient,
+    topic: str,
+    subscription_async: str,
+    capsys: CaptureFixture[str],
+) -> None:
+
+    typed_backoff = cast(
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    )
+
+    @typed_backoff
+    def eventually_consistent_test() -> None:
+        _publish_messages(publisher_client, topic)
+
+        subscriber.receive_messages_with_exactly_once_delivery_enabled(PROJECT_ID, SUBSCRIPTION_ASYNC, 10)
+
+        out, _ = capsys.readouterr()
+        assert "Listening" in out
+        assert subscription_async in out
+        assert "Received" in out
+        assert "Ack" in out
+
+    eventually_consistent_test()
+
+
 def test_listen_for_errors(
     publisher_client: pubsub_v1.PublisherClient,
     topic: str,

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -639,7 +639,9 @@ def test_receive_messages_with_exactly_once_delivery_enabled(
     def eventually_consistent_test() -> None:
         _publish_messages(publisher_client, topic)
 
-        subscriber.receive_messages_with_exactly_once_delivery_enabled(PROJECT_ID, SUBSCRIPTION_ASYNC, 10)
+        subscriber.receive_messages_with_exactly_once_delivery_enabled(
+            PROJECT_ID, SUBSCRIPTION_ASYNC, 10
+        )
 
         out, _ = capsys.readouterr()
         assert "Listening" in out


### PR DESCRIPTION
Towards b/221257565