### PR TITLE
feat: return singleton success future for exactly-once methods in Message

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -40,6 +40,9 @@ Message {{
   attributes: {}
 }}"""
 
+_SUCCESS_FUTURE = futures.Future()
+_SUCCESS_FUTURE.set_result(AcknowledgeStatus.SUCCESS)
+
 
 def _indent(lines: str, prefix: str = "  ") -> str:
     """Indent some text.
@@ -291,12 +294,12 @@ class Message(object):
             pubsub_v1.subscriber.exceptions.AcknowledgeError exception
             will be thrown.
         """
-        future = futures.Future()
-        req_future = None
         if self._exactly_once_delivery_enabled_func():
+            future = futures.Future()
             req_future = future
         else:
-            future.set_result(AcknowledgeStatus.SUCCESS)
+            future = _SUCCESS_FUTURE
+            req_future = None
         time_to_ack = math.ceil(time.time() - self._received_timestamp)
         self._request_queue.put(
             requests.AckRequest(
@@ -390,12 +393,12 @@ class Message(object):
             will be thrown.
 
         """
-        future = futures.Future()
-        req_future = None
         if self._exactly_once_delivery_enabled_func():
+            future = futures.Future()
             req_future = future
         else:
-            future.set_result(AcknowledgeStatus.SUCCESS)
+            future = _SUCCESS_FUTURE
+            req_future = None
 
         self._request_queue.put(
             requests.ModAckRequest(
@@ -451,12 +454,12 @@ class Message(object):
             will be thrown.
 
         """
-        future = futures.Future()
-        req_future = None
         if self._exactly_once_delivery_enabled_func():
+            future = futures.Future()
             req_future = future
         else:
-            future.set_result(AcknowledgeStatus.SUCCESS)
+            future = _SUCCESS_FUTURE
+            req_future = None
 
         self._request_queue.put(
             requests.NackRequest(

--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -294,6 +294,7 @@ class Message(object):
             pubsub_v1.subscriber.exceptions.AcknowledgeError exception
             will be thrown.
         """
+        req_future: Optional[futures.Future]
         if self._exactly_once_delivery_enabled_func():
             future = futures.Future()
             req_future = future
@@ -393,6 +394,7 @@ class Message(object):
             will be thrown.
 
         """
+        req_future: Optional[futures.Future]
         if self._exactly_once_delivery_enabled_func():
             future = futures.Future()
             req_future = future
@@ -454,6 +456,7 @@ class Message(object):
             will be thrown.
 
         """
+        req_future: Optional[futures.Future]
         if self._exactly_once_delivery_enabled_func():
             future = futures.Future()
             req_future = future

--- a/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -156,6 +156,7 @@ def test_ack_with_response_exactly_once_delivery_disabled():
             )
         )
         assert future.result() == AcknowledgeStatus.SUCCESS
+        assert future == message._SUCCESS_FUTURE
         check_call_types(put, requests.AckRequest)
 
 
@@ -205,6 +206,7 @@ def test_modify_ack_deadline_with_response_exactly_once_delivery_disabled():
             requests.ModAckRequest(ack_id="bogus_ack_id", seconds=60, future=None)
         )
         assert future.result() == AcknowledgeStatus.SUCCESS
+        assert future == message._SUCCESS_FUTURE
         check_call_types(put, requests.ModAckRequest)
 
 
@@ -242,6 +244,7 @@ def test_nack_with_response_exactly_once_delivery_disabled():
             )
         )
         assert future.result() == AcknowledgeStatus.SUCCESS
+        assert future == message._SUCCESS_FUTURE
         check_call_types(put, requests.NackRequest)
 
 


### PR DESCRIPTION
This is a small change to return a singleton success future that's constructed once instead of making a new future every time for *_with_response methods. We don't want to guarantee that we'll always return a distinct future object. This issue was raised in https://github.com/googleapis/python-pubsublite/pull/312.