### PR TITLE
feat: increase GRPC max metadata size to 4 MB

### DIFF
--- a/google/pubsub_v1/services/publisher/transports/grpc.py
+++ b/google/pubsub_v1/services/publisher/transports/grpc.py
@@ -173,6 +173,7 @@ class PublisherGrpcTransport(PublisherTransport):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/google/pubsub_v1/services/publisher/transports/grpc_asyncio.py
+++ b/google/pubsub_v1/services/publisher/transports/grpc_asyncio.py
@@ -218,6 +218,7 @@ class PublisherGrpcAsyncIOTransport(PublisherTransport):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/google/pubsub_v1/services/schema_service/transports/grpc.py
+++ b/google/pubsub_v1/services/schema_service/transports/grpc.py
@@ -173,6 +173,7 @@ class SchemaServiceGrpcTransport(SchemaServiceTransport):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/google/pubsub_v1/services/schema_service/transports/grpc_asyncio.py
+++ b/google/pubsub_v1/services/schema_service/transports/grpc_asyncio.py
@@ -218,6 +218,7 @@ class SchemaServiceGrpcAsyncIOTransport(SchemaServiceTransport):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/google/pubsub_v1/services/subscriber/transports/grpc.py
+++ b/google/pubsub_v1/services/subscriber/transports/grpc.py
@@ -175,6 +175,7 @@ class SubscriberGrpcTransport(SubscriberTransport):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
+++ b/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
@@ -220,6 +220,7 @@ class SubscriberGrpcAsyncIOTransport(SubscriberTransport):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/owlbot.py
+++ b/owlbot.py
@@ -72,6 +72,7 @@ for library in s.get_staging_dirs(default_version):
         """options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ]""",
         flags=re.MULTILINE | re.DOTALL,

--- a/tests/unit/gapic/pubsub_v1/test_publisher.py
+++ b/tests/unit/gapic/pubsub_v1/test_publisher.py
@@ -606,6 +606,7 @@ def test_publisher_client_create_channel_credentials_file(
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -2909,6 +2910,7 @@ def test_publisher_transport_create_channel(transport_class, grpc_helpers):
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -2939,6 +2941,7 @@ def test_publisher_grpc_transport_client_cert_source_for_mtls(transport_class):
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -3044,6 +3047,7 @@ def test_publisher_transport_channel_mtls_with_client_cert_source(transport_clas
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )
@@ -3089,6 +3093,7 @@ def test_publisher_transport_channel_mtls_with_adc(transport_class):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/tests/unit/gapic/pubsub_v1/test_schema_service.py
+++ b/tests/unit/gapic/pubsub_v1/test_schema_service.py
@@ -634,6 +634,7 @@ def test_schema_service_client_create_channel_credentials_file(
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -2175,6 +2176,7 @@ def test_schema_service_transport_create_channel(transport_class, grpc_helpers):
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -2208,6 +2210,7 @@ def test_schema_service_grpc_transport_client_cert_source_for_mtls(transport_cla
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -2316,6 +2319,7 @@ def test_schema_service_transport_channel_mtls_with_client_cert_source(transport
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )
@@ -2364,6 +2368,7 @@ def test_schema_service_transport_channel_mtls_with_adc(transport_class):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )

--- a/tests/unit/gapic/pubsub_v1/test_subscriber.py
+++ b/tests/unit/gapic/pubsub_v1/test_subscriber.py
@@ -610,6 +610,7 @@ def test_subscriber_client_create_channel_credentials_file(
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -4204,6 +4205,7 @@ def test_subscriber_transport_create_channel(transport_class, grpc_helpers):
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -4234,6 +4236,7 @@ def test_subscriber_grpc_transport_client_cert_source_for_mtls(transport_class):
             options=[
                 ("grpc.max_send_message_length", -1),
                 ("grpc.max_receive_message_length", -1),
+                ("grpc.max_metadata_size", 4 * 1024 * 1024),
                 ("grpc.keepalive_time_ms", 30000),
             ],
         )
@@ -4339,6 +4342,7 @@ def test_subscriber_transport_channel_mtls_with_client_cert_source(transport_cla
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )
@@ -4384,6 +4388,7 @@ def test_subscriber_transport_channel_mtls_with_adc(transport_class):
                 options=[
                     ("grpc.max_send_message_length", -1),
                     ("grpc.max_receive_message_length", -1),
+                    ("grpc.max_metadata_size", 4 * 1024 * 1024),
                     ("grpc.keepalive_time_ms", 30000),
                 ],
             )


### PR DESCRIPTION
* Ack/modack operations on subscriptions with exactly-once delivery enabled may return up to 4 MB of metadata (about ack/modack success/failure)
* It's unclear what the current limit is (I searched far and wide), but it seems to be lower than 4 MB. So, we're currently seeing subscription StreamingPull stream closures as a result of this low limit. We aim to keep subscription the same for subscribers to exactly-once subscriptions, even if they don't use the new *with_response methods, so this fix ensures that.
