### PR TITLE
CI: add samples python 3.9, 3.10 to required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -13,3 +13,5 @@ branchProtectionRules:
     - 'Samples - Lint'
     - 'Samples - Python 3.7'
     - 'Samples - Python 3.8'
+    - 'Samples - Python 3.9'
+    - 'Samples - Python 3.10'


### PR DESCRIPTION
Ensure all python versions pass before merging.