### PR TITLE
Samples(test): Extend timeout eod receive test

### DIFF
--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -111,7 +111,6 @@ def exactly_once_delivery_topic(
 
     publisher_client.delete_topic(request={"topic": topic.name})
 
-
 @pytest.fixture(scope="module")
 def subscriber_client() -> Generator[pubsub_v1.SubscriberClient, None, None]:
     subscriber_client = pubsub_v1.SubscriberClient()
@@ -159,8 +158,7 @@ def subscription_sync(
     yield subscription.name
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=300),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
     )
 
     @typed_backoff
@@ -241,12 +239,10 @@ def subscription_eod(
     print("for " + subscription_path)
 
     try:
-        print("calling get subscription")
         subscription = subscriber_client.get_subscription(
             request={"subscription": subscription_path}
         )
     except NotFound:
-        print("except NotFound, creating subscription")
         subscription = subscriber_client.create_subscription(
             request={
                 "name": subscription_path,
@@ -254,7 +250,6 @@ def subscription_eod(
                 "enable_exactly_once_delivery": True,
             }
         )
-    print("returning subscription.name = " + subscription.name)
 
     yield subscription.name
 
@@ -503,8 +498,7 @@ def test_create_push_subscription(
     capsys: CaptureFixture[str],
 ) -> None:
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=60),
+    Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
     )
 
     # The scope of `subscription_path` is limited to this function.
@@ -559,8 +553,7 @@ def test_delete_subscription(
     subscriber.delete_subscription(PROJECT_ID, SUBSCRIPTION_ADMIN)
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=60),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
     )
 
     @typed_backoff
@@ -581,8 +574,7 @@ def test_receive(
 ) -> None:
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=60),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
     )
 
     @typed_backoff
@@ -607,8 +599,7 @@ def test_receive_with_custom_attributes(
 ) -> None:
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=60),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
     )
 
     @typed_backoff
@@ -636,8 +627,7 @@ def test_receive_with_flow_control(
 ) -> None:
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=300),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
     )
 
     @typed_backoff
@@ -667,8 +657,7 @@ def test_receive_with_blocking_shutdown(
     _shut_down = re.compile(r".*done waiting.*stream shutdown.*", flags=re.IGNORECASE)
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=300),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
     )
 
     @typed_backoff
@@ -748,8 +737,7 @@ def test_listen_for_errors(
 ) -> None:
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=60),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
     )
 
     @typed_backoff
@@ -790,8 +778,7 @@ def test_receive_synchronously_with_lease(
 ) -> None:
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=300),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
     )
 
     @typed_backoff

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -51,7 +51,7 @@ FILTER = 'attributes.author="unknown"'
 C = TypeVar("C", bound=Callable[..., Any])
 
 typed_flaky = cast(Callable[[C], C], flaky(max_runs=3, min_passes=1))
-typed_super_flaky = cast(Callable[[C], C], flaky(max_runs=5, min_passes=5))
+typed_super_flaky = cast(Callable[[C], C], flaky(max_runs=10, min_passes=10))
 
 
 @pytest.fixture(scope="module")
@@ -718,7 +718,7 @@ def test_receive_messages_with_exactly_once_delivery_enabled(
     )
 
     subscriber.receive_messages_with_exactly_once_delivery_enabled(
-        PROJECT_ID, SUBSCRIPTION_EOD, 100
+        PROJECT_ID, SUBSCRIPTION_EOD, 200
     )
 
     out, _ = capsys.readouterr()

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -53,6 +53,7 @@ C = TypeVar("C", bound=Callable[..., Any])
 typed_flaky = cast(Callable[[C], C], flaky(max_runs=3, min_passes=1))
 typed_super_flaky = cast(Callable[[C], C], flaky(max_runs=5, min_passes=5))
 
+
 @pytest.fixture(scope="module")
 def publisher_client() -> Generator[pubsub_v1.PublisherClient, None, None]:
     yield pubsub_v1.PublisherClient()
@@ -256,7 +257,7 @@ def subscription_eod(
     print("returning subscription.name = " + subscription.name)
 
     yield subscription.name
-    
+
     subscriber_client.delete_subscription(request={"subscription": subscription.name})
 
 
@@ -726,18 +727,17 @@ def test_receive_messages_with_exactly_once_delivery_enabled(
 ) -> None:
 
     message_ids = _publish_messages(
-            regional_publisher_client, exactly_once_delivery_topic
-        )
+        regional_publisher_client, exactly_once_delivery_topic
+    )
 
     subscriber.receive_messages_with_exactly_once_delivery_enabled(
-            PROJECT_ID, SUBSCRIPTION_EOD, 100
-        )
+        PROJECT_ID, SUBSCRIPTION_EOD, 100
+    )
 
     out, _ = capsys.readouterr()
     assert subscription_eod in out
     for message_id in message_ids:
         assert message_id in out
-
 
 
 def test_listen_for_errors(

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -111,6 +111,7 @@ def exactly_once_delivery_topic(
 
     publisher_client.delete_topic(request={"topic": topic.name})
 
+
 @pytest.fixture(scope="module")
 def subscriber_client() -> Generator[pubsub_v1.SubscriberClient, None, None]:
     subscriber_client = pubsub_v1.SubscriberClient()
@@ -236,7 +237,6 @@ def subscription_eod(
     subscription_path = subscriber_client.subscription_path(
         PROJECT_ID, SUBSCRIPTION_EOD
     )
-    print("for " + subscription_path)
 
     try:
         subscription = subscriber_client.get_subscription(
@@ -498,7 +498,7 @@ def test_create_push_subscription(
     capsys: CaptureFixture[str],
 ) -> None:
     typed_backoff = cast(
-    Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
     )
 
     # The scope of `subscription_path` is limited to this function.
@@ -525,13 +525,11 @@ def test_create_push_subscription(
 
 
 def test_update_push_suscription(
-    subscription_admin: str,
-    capsys: CaptureFixture[str],
+    subscription_admin: str, capsys: CaptureFixture[str],
 ) -> None:
 
     typed_backoff = cast(
-        Callable[[C], C],
-        backoff.on_exception(backoff.expo, Unknown, max_time=60),
+        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=60),
     )
 
     @typed_backoff


### PR DESCRIPTION
Added typed_super_flaky to force multiple runs of eod receive test.
Lengthened timeout from 10 sec to 200 sec handle NOT_FOUND errors.

Fixes #638 🦕
