### PR TITLE
Docs: Mark exactly once delivery as preview

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -13,3 +13,5 @@ branchProtectionRules:
     - 'Samples - Lint'
     - 'Samples - Python 3.7'
     - 'Samples - Python 3.8'
+    - 'Samples - Python 3.9'
+    - 'Samples - Python 3.10'

--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -246,7 +246,10 @@ class Message(object):
             receive any given message more than once. If you need strong
             guarantees about acks and re-deliveres, enable exactly-once
             delivery on your subscription and use the `ack_with_response`
-            method instead.
+            method instead. Exactly once delivery is a preview feature.
+            For more details, see:
+            https://cloud.google.com/pubsub/docs/exactly-once-delivery."
+
         """
         time_to_ack = math.ceil(time.time() - self._received_timestamp)
         self._request_queue.put(
@@ -268,13 +271,6 @@ class Message(object):
         *finished* processing them, so that in the event of a failure,
         you receive the message again.
 
-        If exactly-once delivery is enabled on the subscription, the
-        future returned by this method tracks the state of acknowledgement
-        operation. If the future completes successfully, the message is
-        guaranteed NOT to be re-delivered. Otherwise, the future will
-        contain an exception with more details about the failure and the
-        message may be re-delivered.
-
         If exactly-once delivery is NOT enabled on the subscription, the
         future returns immediately with an AcknowledgeStatus.SUCCESS.
         Since acks in Cloud Pub/Sub are best effort when exactly-once
@@ -282,6 +278,16 @@ class Message(object):
         re-deliveries are possible, you should ensure that your processing
         code is idempotent, as you may receive any given message more than
         once.
+
+        If exactly-once delivery is enabled on the subscription, the
+        future returned by this method tracks the state of acknowledgement
+        operation. If the future completes successfully, the message is
+        guaranteed NOT to be re-delivered. Otherwise, the future will
+        contain an exception with more details about the failure and the
+        message may be re-delivered.
+
+        Exactly once delivery is a preview feature. For more details,
+        see https://cloud.google.com/pubsub/docs/exactly-once-delivery."
 
         Returns:
             A :class:`~google.cloud.pubsub_v1.subscriber.futures.Future`
@@ -363,6 +369,12 @@ class Message(object):
         if you are implementing your own custom subclass of
         :class:`~.pubsub_v1.subcriber._consumer.Consumer`.
 
+        If exactly-once delivery is NOT enabled on the subscription, the
+        future returns immediately with an AcknowledgeStatus.SUCCESS.
+        Since modify-ack-deadline operations in Cloud Pub/Sub are best effort
+        when exactly-once delivery is disabled, the message may be re-delivered
+        within the set deadline.
+
         If exactly-once delivery is enabled on the subscription, the
         future returned by this method tracks the state of the
         modify-ack-deadline operation. If the future completes successfully,
@@ -370,12 +382,9 @@ class Message(object):
         Otherwise, the future will contain an exception with more details about
         the failure and the message will be redelivered according to its
         currently-set ack deadline.
-
-        If exactly-once delivery is NOT enabled on the subscription, the
-        future returns immediately with an AcknowledgeStatus.SUCCESS.
-        Since modify-ack-deadline operations in Cloud Pub/Sub are best effort
-        when exactly-once delivery is disabled, the message may be re-delivered
-        within the set deadline.
+        
+        Exactly once delivery is a preview feature. For more details,
+        see https://cloud.google.com/pubsub/docs/exactly-once-delivery."
 
         Args:
             seconds:
@@ -434,6 +443,9 @@ class Message(object):
         may take place immediately or after a delay, and may arrive at this subscriber
         or another.
 
+        If exactly-once delivery is NOT enabled on the subscription, the
+        future returns immediately with an AcknowledgeStatus.SUCCESS.
+        
         If exactly-once delivery is enabled on the subscription, the
         future returned by this method tracks the state of the
         nack operation. If the future completes successfully,
@@ -441,8 +453,8 @@ class Message(object):
         Otherwise, the future will contain an exception with more details about
         the failure.
 
-        If exactly-once delivery is NOT enabled on the subscription, the
-        future returns immediately with an AcknowledgeStatus.SUCCESS.
+        Exactly once delivery is a preview feature. For more details,
+        see https://cloud.google.com/pubsub/docs/exactly-once-delivery."
 
         Returns:
             A :class:`~google.cloud.pubsub_v1.subscriber.futures.Future`

--- a/google/cloud/pubsub_v1/subscriber/message.py
+++ b/google/cloud/pubsub_v1/subscriber/message.py
@@ -382,7 +382,7 @@ class Message(object):
         Otherwise, the future will contain an exception with more details about
         the failure and the message will be redelivered according to its
         currently-set ack deadline.
-        
+
         Exactly once delivery is a preview feature. For more details,
         see https://cloud.google.com/pubsub/docs/exactly-once-delivery."
 
@@ -445,7 +445,7 @@ class Message(object):
 
         If exactly-once delivery is NOT enabled on the subscription, the
         future returns immediately with an AcknowledgeStatus.SUCCESS.
-        
+
         If exactly-once delivery is enabled on the subscription, the
         future returned by this method tracks the state of the
         nack operation. If the future completes successfully,

--- a/google/pubsub_v1/services/publisher/async_client.py
+++ b/google/pubsub_v1/services/publisher/async_client.py
@@ -16,7 +16,7 @@
 from collections import OrderedDict
 import functools
 import re
-from typing import Dict, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, Mapping, Optional, Sequence, Tuple, Type, Union
 import pkg_resources
 
 from google.api_core.client_options import ClientOptions
@@ -220,7 +220,6 @@ class PublisherAsyncClient:
         name rules]
         (https://cloud.google.com/pubsub/docs/admin#resource_names).
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -329,7 +328,6 @@ class PublisherAsyncClient:
         r"""Updates an existing topic. Note that certain
         properties of a topic are not modifiable.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -417,7 +415,6 @@ class PublisherAsyncClient:
     ) -> pubsub.PublishResponse:
         r"""Adds one or more messages to the topic. Returns ``NOT_FOUND`` if
         the topic does not exist.
-
 
         .. code-block:: python
 
@@ -758,7 +755,6 @@ class PublisherAsyncClient:
         r"""Lists the names of the attached subscriptions on this
         topic.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -883,7 +879,6 @@ class PublisherAsyncClient:
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-
 
         .. code-block:: python
 
@@ -1010,7 +1005,6 @@ class PublisherAsyncClient:
         subscriptions to this topic are not deleted, but their ``topic``
         field is set to ``_deleted-topic_``.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1106,7 +1100,6 @@ class PublisherAsyncClient:
         ``StreamingPull`` requests will return FAILED_PRECONDITION. If
         the subscription is a push subscription, pushes to the endpoint
         will stop.
-
 
         .. code-block:: python
 

--- a/google/pubsub_v1/services/publisher/client.py
+++ b/google/pubsub_v1/services/publisher/client.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 import functools
 import os
 import re
-from typing import Dict, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, Mapping, Optional, Sequence, Tuple, Type, Union
 import pkg_resources
 
 from google.api_core import client_options as client_options_lib
@@ -503,7 +503,6 @@ class PublisherClient(metaclass=PublisherClientMeta):
         name rules]
         (https://cloud.google.com/pubsub/docs/admin#resource_names).
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -604,7 +603,6 @@ class PublisherClient(metaclass=PublisherClientMeta):
         r"""Updates an existing topic. Note that certain
         properties of a topic are not modifiable.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -685,7 +683,6 @@ class PublisherClient(metaclass=PublisherClientMeta):
     ) -> pubsub.PublishResponse:
         r"""Adds one or more messages to the topic. Returns ``NOT_FOUND`` if
         the topic does not exist.
-
 
         .. code-block:: python
 
@@ -992,7 +989,6 @@ class PublisherClient(metaclass=PublisherClientMeta):
         r"""Lists the names of the attached subscriptions on this
         topic.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1107,7 +1103,6 @@ class PublisherClient(metaclass=PublisherClientMeta):
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-
 
         .. code-block:: python
 
@@ -1224,7 +1219,6 @@ class PublisherClient(metaclass=PublisherClientMeta):
         subscriptions to this topic are not deleted, but their ``topic``
         field is set to ``_deleted-topic_``.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1312,7 +1306,6 @@ class PublisherClient(metaclass=PublisherClientMeta):
         ``StreamingPull`` requests will return FAILED_PRECONDITION. If
         the subscription is a push subscription, pushes to the endpoint
         will stop.
-
 
         .. code-block:: python
 

--- a/google/pubsub_v1/services/publisher/transports/base.py
+++ b/google/pubsub_v1/services/publisher/transports/base.py
@@ -86,6 +86,7 @@ class PublisherTransport(abc.ABC):
             always_use_jwt_access (Optional[bool]): Whether self signed JWT should
                 be used for service account credentials.
         """
+
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
         if ":" not in host:
             host += ":443"
@@ -389,6 +390,10 @@ class PublisherTransport(abc.ABC):
             Awaitable[iam_policy_pb2.TestIamPermissionsResponse],
         ],
     ]:
+        raise NotImplementedError()
+
+    @property
+    def kind(self) -> str:
         raise NotImplementedError()
 
 

--- a/google/pubsub_v1/services/publisher/transports/grpc.py
+++ b/google/pubsub_v1/services/publisher/transports/grpc.py
@@ -565,5 +565,9 @@ class PublisherGrpcTransport(PublisherTransport):
     def close(self):
         self.grpc_channel.close()
 
+    @property
+    def kind(self) -> str:
+        return "grpc"
+
 
 __all__ = ("PublisherGrpcTransport",)

--- a/google/pubsub_v1/services/schema_service/async_client.py
+++ b/google/pubsub_v1/services/schema_service/async_client.py
@@ -16,7 +16,7 @@
 from collections import OrderedDict
 import functools
 import re
-from typing import Dict, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, Mapping, Optional, Sequence, Tuple, Type, Union
 import pkg_resources
 
 from google.api_core.client_options import ClientOptions

--- a/google/pubsub_v1/services/schema_service/client.py
+++ b/google/pubsub_v1/services/schema_service/client.py
@@ -16,7 +16,7 @@
 from collections import OrderedDict
 import os
 import re
-from typing import Dict, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, Mapping, Optional, Sequence, Tuple, Type, Union
 import pkg_resources
 
 from google.api_core import client_options as client_options_lib

--- a/google/pubsub_v1/services/schema_service/transports/base.py
+++ b/google/pubsub_v1/services/schema_service/transports/base.py
@@ -87,6 +87,7 @@ class SchemaServiceTransport(abc.ABC):
             always_use_jwt_access (Optional[bool]): Whether self signed JWT should
                 be used for service account credentials.
         """
+
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
         if ":" not in host:
             host += ":443"
@@ -253,6 +254,10 @@ class SchemaServiceTransport(abc.ABC):
             Awaitable[iam_policy_pb2.TestIamPermissionsResponse],
         ],
     ]:
+        raise NotImplementedError()
+
+    @property
+    def kind(self) -> str:
         raise NotImplementedError()
 
 

--- a/google/pubsub_v1/services/schema_service/transports/grpc.py
+++ b/google/pubsub_v1/services/schema_service/transports/grpc.py
@@ -468,5 +468,9 @@ class SchemaServiceGrpcTransport(SchemaServiceTransport):
     def close(self):
         self.grpc_channel.close()
 
+    @property
+    def kind(self) -> str:
+        return "grpc"
+
 
 __all__ = ("SchemaServiceGrpcTransport",)

--- a/google/pubsub_v1/services/subscriber/async_client.py
+++ b/google/pubsub_v1/services/subscriber/async_client.py
@@ -18,6 +18,7 @@ import functools
 import re
 from typing import (
     Dict,
+    Mapping,
     Optional,
     AsyncIterable,
     Awaitable,
@@ -244,7 +245,6 @@ class SubscriberAsyncClient:
         generated name is populated in the returned Subscription object.
         Note that for REST API requests, you must specify a name in the
         request.
-
 
         .. code-block:: python
 
@@ -518,7 +518,6 @@ class SubscriberAsyncClient:
         properties of a subscription, such as its topic, are not
         modifiable.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -729,7 +728,6 @@ class SubscriberAsyncClient:
         new one has no association with the old subscription or its
         topic unless the same topic is specified.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -830,7 +828,6 @@ class SubscriberAsyncClient:
         redelivery if the processing was interrupted. Note that this
         does not modify the subscription-level ``ackDeadlineSeconds``
         used for subsequent messages.
-
 
         .. code-block:: python
 
@@ -961,7 +958,6 @@ class SubscriberAsyncClient:
         Acknowledging a message more than once will not result in an
         error.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1070,7 +1066,6 @@ class SubscriberAsyncClient:
         r"""Pulls messages from the server. The server may return
         ``UNAVAILABLE`` if there are too many concurrent pull requests
         pending for the given subscription.
-
 
         .. code-block:: python
 
@@ -1219,7 +1214,6 @@ class SubscriberAsyncClient:
         re-establish the stream. Flow control can be achieved by
         configuring the underlying RPC channel.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1320,7 +1314,6 @@ class SubscriberAsyncClient:
         the endpoint URL and other attributes of a push subscription.
         Messages will accumulate for delivery continuously through the
         call regardless of changes to the ``PushConfig``.
-
 
         .. code-block:: python
 
@@ -1436,7 +1429,6 @@ class SubscriberAsyncClient:
         acknowledgment state of messages in an existing
         subscription to the state captured by a snapshot.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1549,7 +1541,6 @@ class SubscriberAsyncClient:
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-
 
         .. code-block:: python
 
@@ -1688,7 +1679,6 @@ class SubscriberAsyncClient:
         Note that for REST API requests, you must specify a name in the
         request.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1826,7 +1816,6 @@ class SubscriberAsyncClient:
         existing subscription to the state captured by a
         snapshot.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1923,7 +1912,6 @@ class SubscriberAsyncClient:
         new one may be created with the same name, but the new one has
         no association with the old snapshot or its subscription, unless
         the same subscription is specified.
-
 
         .. code-block:: python
 
@@ -2023,7 +2011,6 @@ class SubscriberAsyncClient:
         in an existing subscription to the state captured by a snapshot.
         Note that both the subscription and the snapshot must be on the
         same topic.
-
 
         .. code-block:: python
 

--- a/google/pubsub_v1/services/subscriber/client.py
+++ b/google/pubsub_v1/services/subscriber/client.py
@@ -17,7 +17,17 @@ from collections import OrderedDict
 import functools
 import os
 import re
-from typing import Dict, Optional, Iterable, Iterator, Sequence, Tuple, Type, Union
+from typing import (
+    Dict,
+    Mapping,
+    Optional,
+    Iterable,
+    Iterator,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 import warnings
 import pkg_resources
 
@@ -518,7 +528,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         Note that for REST API requests, you must specify a name in the
         request.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -771,7 +780,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         properties of a subscription, such as its topic, are not
         modifiable.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -965,7 +973,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         new one has no association with the old subscription or its
         topic unless the same topic is specified.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1058,7 +1065,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         redelivery if the processing was interrupted. Note that this
         does not modify the subscription-level ``ackDeadlineSeconds``
         used for subsequent messages.
-
 
         .. code-block:: python
 
@@ -1181,7 +1187,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         Acknowledging a message more than once will not result in an
         error.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1282,7 +1287,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         r"""Pulls messages from the server. The server may return
         ``UNAVAILABLE`` if there are too many concurrent pull requests
         pending for the given subscription.
-
 
         .. code-block:: python
 
@@ -1421,7 +1425,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         re-establish the stream. Flow control can be achieved by
         configuring the underlying RPC channel.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1511,7 +1514,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         the endpoint URL and other attributes of a push subscription.
         Messages will accumulate for delivery continuously through the
         call regardless of changes to the ``PushConfig``.
-
 
         .. code-block:: python
 
@@ -1619,7 +1621,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         acknowledgment state of messages in an existing
         subscription to the state captured by a snapshot.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -1722,7 +1723,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-
 
         .. code-block:: python
 
@@ -1850,7 +1850,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         generated name is populated in the returned Snapshot object.
         Note that for REST API requests, you must specify a name in the
         request.
-
 
         .. code-block:: python
 
@@ -1981,7 +1980,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         existing subscription to the state captured by a
         snapshot.
 
-
         .. code-block:: python
 
             from google import pubsub_v1
@@ -2071,7 +2069,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         new one may be created with the same name, but the new one has
         no association with the old snapshot or its subscription, unless
         the same subscription is specified.
-
 
         .. code-block:: python
 
@@ -2163,7 +2160,6 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         in an existing subscription to the state captured by a snapshot.
         Note that both the subscription and the snapshot must be on the
         same topic.
-
 
         .. code-block:: python
 

--- a/google/pubsub_v1/services/subscriber/transports/base.py
+++ b/google/pubsub_v1/services/subscriber/transports/base.py
@@ -86,6 +86,7 @@ class SubscriberTransport(abc.ABC):
             always_use_jwt_access (Optional[bool]): Whether self signed JWT should
                 be used for service account credentials.
         """
+
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
         if ":" not in host:
             host += ":443"
@@ -550,6 +551,10 @@ class SubscriberTransport(abc.ABC):
             Awaitable[iam_policy_pb2.TestIamPermissionsResponse],
         ],
     ]:
+        raise NotImplementedError()
+
+    @property
+    def kind(self) -> str:
         raise NotImplementedError()
 
 

--- a/google/pubsub_v1/services/subscriber/transports/grpc.py
+++ b/google/pubsub_v1/services/subscriber/transports/grpc.py
@@ -824,5 +824,9 @@ class SubscriberGrpcTransport(SubscriberTransport):
     def close(self):
         self.grpc_channel.close()
 
+    @property
+    def kind(self) -> str:
+        return "grpc"
+
 
 __all__ = ("SubscriberGrpcTransport",)

--- a/google/pubsub_v1/types/pubsub.py
+++ b/google/pubsub_v1/types/pubsub.py
@@ -132,7 +132,7 @@ class Topic(proto.Message):
             (``+``) or percent signs (``%``). It must be between 3 and
             255 characters in length, and it must not start with
             ``"goog"``.
-        labels (Sequence[google.pubsub_v1.types.Topic.LabelsEntry]):
+        labels (Mapping[str, str]):
             See [Creating and managing labels]
             (https://cloud.google.com/pubsub/docs/labels).
         message_storage_policy (google.pubsub_v1.types.MessageStoragePolicy):
@@ -217,7 +217,7 @@ class PubsubMessage(proto.Message):
             The message data field. If this field is
             empty, the message must contain at least one
             attribute.
-        attributes (Sequence[google.pubsub_v1.types.PubsubMessage.AttributesEntry]):
+        attributes (Mapping[str, str]):
             Attributes for this message. If this field is
             empty, the message must contain non-empty data.
             This can be used to filter messages on the
@@ -623,7 +623,7 @@ class Subscription(proto.Message):
             thus configures how far back in time a ``Seek`` can be done.
             Defaults to 7 days. Cannot be more than 7 days or less than
             10 minutes.
-        labels (Sequence[google.pubsub_v1.types.Subscription.LabelsEntry]):
+        labels (Mapping[str, str]):
             See <a
             href="https://cloud.google.com/pubsub/docs/labels">
             Creating and managing labels</a>.
@@ -891,7 +891,7 @@ class PushConfig(proto.Message):
             A URL locating the endpoint to which messages should be
             pushed. For example, a Webhook endpoint might use
             ``https://example.com/push``.
-        attributes (Sequence[google.pubsub_v1.types.PushConfig.AttributesEntry]):
+        attributes (Mapping[str, str]):
             Endpoint configuration attributes that can be used to
             control different aspects of the message delivery.
 
@@ -1533,7 +1533,7 @@ class CreateSnapshotRequest(proto.Message):
             topic following the successful completion of the
             CreateSnapshot request. Format is
             ``projects/{project}/subscriptions/{sub}``.
-        labels (Sequence[google.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry]):
+        labels (Mapping[str, str]):
             See <a
             href="https://cloud.google.com/pubsub/docs/labels">
             Creating and managing labels</a>.
@@ -1605,7 +1605,7 @@ class Snapshot(proto.Message):
             expire in 4 days. The service will refuse to create a
             snapshot that would expire in less than 1 hour after
             creation.
-        labels (Sequence[google.pubsub_v1.types.Snapshot.LabelsEntry]):
+        labels (Mapping[str, str]):
             See [Creating and managing labels]
             (https://cloud.google.com/pubsub/docs/labels).
     """

--- a/samples/generated_samples/snippet_metadata_pubsub_v1.json
+++ b/samples/generated_samples/snippet_metadata_pubsub_v1.json
@@ -1,16 +1,61 @@
 {
+  "clientLibrary": {
+    "apis": [
+      {
+        "id": "google.pubsub.v1",
+        "version": "v1"
+      }
+    ],
+    "language": "PYTHON",
+    "name": "google-cloud-pubsub"
+  },
   "snippets": [
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.create_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.CreateTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "CreateTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.Topic"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Topic",
+        "shortName": "create_topic"
       },
+      "description": "Sample for CreateTopic",
       "file": "pubsub_v1_generated_publisher_create_topic_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_CreateTopic_async",
       "segments": [
         {
@@ -43,18 +88,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_create_topic_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.create_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.CreateTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "CreateTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.Topic"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Topic",
+        "shortName": "create_topic"
       },
+      "description": "Sample for CreateTopic",
       "file": "pubsub_v1_generated_publisher_create_topic_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_CreateTopic_sync",
       "segments": [
         {
@@ -87,19 +168,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_create_topic_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.delete_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.DeleteTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "DeleteTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteTopicRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_topic"
       },
+      "description": "Sample for DeleteTopic",
       "file": "pubsub_v1_generated_publisher_delete_topic_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_DeleteTopic_async",
       "segments": [
         {
@@ -130,18 +246,53 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_delete_topic_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.delete_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.DeleteTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "DeleteTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteTopicRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_topic"
       },
+      "description": "Sample for DeleteTopic",
       "file": "pubsub_v1_generated_publisher_delete_topic_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_DeleteTopic_sync",
       "segments": [
         {
@@ -172,19 +323,51 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_delete_topic_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.detach_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.DetachSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "DetachSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DetachSubscriptionRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.DetachSubscriptionResponse",
+        "shortName": "detach_subscription"
       },
+      "description": "Sample for DetachSubscription",
       "file": "pubsub_v1_generated_publisher_detach_subscription_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_DetachSubscription_async",
       "segments": [
         {
@@ -217,18 +400,50 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_detach_subscription_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.detach_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.DetachSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "DetachSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DetachSubscriptionRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.DetachSubscriptionResponse",
+        "shortName": "detach_subscription"
       },
+      "description": "Sample for DetachSubscription",
       "file": "pubsub_v1_generated_publisher_detach_subscription_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_DetachSubscription_sync",
       "segments": [
         {
@@ -261,19 +476,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_detach_subscription_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.get_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.GetTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "GetTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetTopicRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Topic",
+        "shortName": "get_topic"
       },
+      "description": "Sample for GetTopic",
       "file": "pubsub_v1_generated_publisher_get_topic_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_GetTopic_async",
       "segments": [
         {
@@ -306,18 +557,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_get_topic_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.get_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.GetTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "GetTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetTopicRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Topic",
+        "shortName": "get_topic"
       },
+      "description": "Sample for GetTopic",
       "file": "pubsub_v1_generated_publisher_get_topic_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_GetTopic_sync",
       "segments": [
         {
@@ -350,19 +637,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_get_topic_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.list_topic_snapshots",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.ListTopicSnapshots",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "ListTopicSnapshots"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListTopicSnapshotsRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager",
+        "shortName": "list_topic_snapshots"
       },
+      "description": "Sample for ListTopicSnapshots",
       "file": "pubsub_v1_generated_publisher_list_topic_snapshots_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_ListTopicSnapshots_async",
       "segments": [
         {
@@ -395,18 +718,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_list_topic_snapshots_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.list_topic_snapshots",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.ListTopicSnapshots",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "ListTopicSnapshots"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListTopicSnapshotsRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager",
+        "shortName": "list_topic_snapshots"
       },
+      "description": "Sample for ListTopicSnapshots",
       "file": "pubsub_v1_generated_publisher_list_topic_snapshots_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_ListTopicSnapshots_sync",
       "segments": [
         {
@@ -439,19 +798,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_list_topic_snapshots_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.list_topic_subscriptions",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.ListTopicSubscriptions",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "ListTopicSubscriptions"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListTopicSubscriptionsRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager",
+        "shortName": "list_topic_subscriptions"
       },
+      "description": "Sample for ListTopicSubscriptions",
       "file": "pubsub_v1_generated_publisher_list_topic_subscriptions_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_ListTopicSubscriptions_async",
       "segments": [
         {
@@ -484,18 +879,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_list_topic_subscriptions_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.list_topic_subscriptions",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.ListTopicSubscriptions",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "ListTopicSubscriptions"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListTopicSubscriptionsRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager",
+        "shortName": "list_topic_subscriptions"
       },
+      "description": "Sample for ListTopicSubscriptions",
       "file": "pubsub_v1_generated_publisher_list_topic_subscriptions_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_ListTopicSubscriptions_sync",
       "segments": [
         {
@@ -528,19 +959,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_list_topic_subscriptions_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.list_topics",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.ListTopics",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "ListTopics"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListTopicsRequest"
+          },
+          {
+            "name": "project",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager",
+        "shortName": "list_topics"
       },
+      "description": "Sample for ListTopics",
       "file": "pubsub_v1_generated_publisher_list_topics_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_ListTopics_async",
       "segments": [
         {
@@ -573,18 +1040,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_list_topics_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.list_topics",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.ListTopics",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "ListTopics"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListTopicsRequest"
+          },
+          {
+            "name": "project",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.publisher.pagers.ListTopicsPager",
+        "shortName": "list_topics"
       },
+      "description": "Sample for ListTopics",
       "file": "pubsub_v1_generated_publisher_list_topics_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_ListTopics_sync",
       "segments": [
         {
@@ -617,19 +1120,59 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_list_topics_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.publish",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.Publish",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "Publish"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.PublishRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "messages",
+            "type": "Sequence[google.pubsub_v1.types.PubsubMessage]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.PublishResponse",
+        "shortName": "publish"
       },
+      "description": "Sample for Publish",
       "file": "pubsub_v1_generated_publisher_publish_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_Publish_async",
       "segments": [
         {
@@ -662,18 +1205,58 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_publish_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.publish",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.Publish",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "Publish"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.PublishRequest"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "messages",
+            "type": "Sequence[google.pubsub_v1.types.PubsubMessage]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.PublishResponse",
+        "shortName": "publish"
       },
+      "description": "Sample for Publish",
       "file": "pubsub_v1_generated_publisher_publish_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_Publish_sync",
       "segments": [
         {
@@ -706,19 +1289,51 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_publish_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherAsyncClient",
+          "shortName": "PublisherAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherAsyncClient.update_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.UpdateTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "UpdateTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.UpdateTopicRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Topic",
+        "shortName": "update_topic"
       },
+      "description": "Sample for UpdateTopic",
       "file": "pubsub_v1_generated_publisher_update_topic_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_UpdateTopic_async",
       "segments": [
         {
@@ -751,18 +1366,50 @@
           "start": 45,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_update_topic_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.PublisherClient",
+          "shortName": "PublisherClient"
+        },
+        "fullName": "google.pubsub_v1.PublisherClient.update_topic",
         "method": {
+          "fullName": "google.pubsub.v1.Publisher.UpdateTopic",
           "service": {
+            "fullName": "google.pubsub.v1.Publisher",
             "shortName": "Publisher"
           },
           "shortName": "UpdateTopic"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.UpdateTopicRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Topic",
+        "shortName": "update_topic"
       },
+      "description": "Sample for UpdateTopic",
       "file": "pubsub_v1_generated_publisher_update_topic_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Publisher_UpdateTopic_sync",
       "segments": [
         {
@@ -795,19 +1442,63 @@
           "start": 45,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_publisher_update_topic_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceAsyncClient",
+          "shortName": "SchemaServiceAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceAsyncClient.create_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.CreateSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "CreateSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.CreateSchemaRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "schema",
+            "type": "google.pubsub_v1.types.Schema"
+          },
+          {
+            "name": "schema_id",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Schema",
+        "shortName": "create_schema"
       },
+      "description": "Sample for CreateSchema",
       "file": "pubsub_v1_generated_schema_service_create_schema_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_CreateSchema_async",
       "segments": [
         {
@@ -840,18 +1531,62 @@
           "start": 46,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_create_schema_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceClient",
+          "shortName": "SchemaServiceClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceClient.create_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.CreateSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "CreateSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.CreateSchemaRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "schema",
+            "type": "google.pubsub_v1.types.Schema"
+          },
+          {
+            "name": "schema_id",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Schema",
+        "shortName": "create_schema"
       },
+      "description": "Sample for CreateSchema",
       "file": "pubsub_v1_generated_schema_service_create_schema_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_CreateSchema_sync",
       "segments": [
         {
@@ -884,19 +1619,54 @@
           "start": 46,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_create_schema_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceAsyncClient",
+          "shortName": "SchemaServiceAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceAsyncClient.delete_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.DeleteSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "DeleteSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteSchemaRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_schema"
       },
+      "description": "Sample for DeleteSchema",
       "file": "pubsub_v1_generated_schema_service_delete_schema_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_DeleteSchema_async",
       "segments": [
         {
@@ -927,18 +1697,53 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_delete_schema_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceClient",
+          "shortName": "SchemaServiceClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceClient.delete_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.DeleteSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "DeleteSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteSchemaRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_schema"
       },
+      "description": "Sample for DeleteSchema",
       "file": "pubsub_v1_generated_schema_service_delete_schema_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_DeleteSchema_sync",
       "segments": [
         {
@@ -969,19 +1774,55 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_delete_schema_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceAsyncClient",
+          "shortName": "SchemaServiceAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceAsyncClient.get_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.GetSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "GetSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetSchemaRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Schema",
+        "shortName": "get_schema"
       },
+      "description": "Sample for GetSchema",
       "file": "pubsub_v1_generated_schema_service_get_schema_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_GetSchema_async",
       "segments": [
         {
@@ -1014,18 +1855,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_get_schema_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceClient",
+          "shortName": "SchemaServiceClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceClient.get_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.GetSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "GetSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetSchemaRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Schema",
+        "shortName": "get_schema"
       },
+      "description": "Sample for GetSchema",
       "file": "pubsub_v1_generated_schema_service_get_schema_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_GetSchema_sync",
       "segments": [
         {
@@ -1058,19 +1935,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_get_schema_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceAsyncClient",
+          "shortName": "SchemaServiceAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceAsyncClient.list_schemas",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.ListSchemas",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "ListSchemas"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListSchemasRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.schema_service.pagers.ListSchemasAsyncPager",
+        "shortName": "list_schemas"
       },
+      "description": "Sample for ListSchemas",
       "file": "pubsub_v1_generated_schema_service_list_schemas_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_ListSchemas_async",
       "segments": [
         {
@@ -1103,18 +2016,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_list_schemas_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceClient",
+          "shortName": "SchemaServiceClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceClient.list_schemas",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.ListSchemas",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "ListSchemas"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListSchemasRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.schema_service.pagers.ListSchemasPager",
+        "shortName": "list_schemas"
       },
+      "description": "Sample for ListSchemas",
       "file": "pubsub_v1_generated_schema_service_list_schemas_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_ListSchemas_sync",
       "segments": [
         {
@@ -1147,19 +2096,51 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_list_schemas_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceAsyncClient",
+          "shortName": "SchemaServiceAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceAsyncClient.validate_message",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.ValidateMessage",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "ValidateMessage"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ValidateMessageRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.ValidateMessageResponse",
+        "shortName": "validate_message"
       },
+      "description": "Sample for ValidateMessage",
       "file": "pubsub_v1_generated_schema_service_validate_message_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_ValidateMessage_async",
       "segments": [
         {
@@ -1192,18 +2173,50 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_validate_message_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceClient",
+          "shortName": "SchemaServiceClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceClient.validate_message",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.ValidateMessage",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "ValidateMessage"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ValidateMessageRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.ValidateMessageResponse",
+        "shortName": "validate_message"
       },
+      "description": "Sample for ValidateMessage",
       "file": "pubsub_v1_generated_schema_service_validate_message_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_ValidateMessage_sync",
       "segments": [
         {
@@ -1236,19 +2249,59 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_validate_message_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceAsyncClient",
+          "shortName": "SchemaServiceAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceAsyncClient.validate_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.ValidateSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "ValidateSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ValidateSchemaRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "schema",
+            "type": "google.pubsub_v1.types.Schema"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.ValidateSchemaResponse",
+        "shortName": "validate_schema"
       },
+      "description": "Sample for ValidateSchema",
       "file": "pubsub_v1_generated_schema_service_validate_schema_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_ValidateSchema_async",
       "segments": [
         {
@@ -1281,18 +2334,58 @@
           "start": 46,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_validate_schema_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SchemaServiceClient",
+          "shortName": "SchemaServiceClient"
+        },
+        "fullName": "google.pubsub_v1.SchemaServiceClient.validate_schema",
         "method": {
+          "fullName": "google.pubsub.v1.SchemaService.ValidateSchema",
           "service": {
+            "fullName": "google.pubsub.v1.SchemaService",
             "shortName": "SchemaService"
           },
           "shortName": "ValidateSchema"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ValidateSchemaRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "schema",
+            "type": "google.pubsub_v1.types.Schema"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.ValidateSchemaResponse",
+        "shortName": "validate_schema"
       },
+      "description": "Sample for ValidateSchema",
       "file": "pubsub_v1_generated_schema_service_validate_schema_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_SchemaService_ValidateSchema_sync",
       "segments": [
         {
@@ -1325,19 +2418,58 @@
           "start": 46,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_schema_service_validate_schema_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.acknowledge",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.Acknowledge",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "Acknowledge"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.AcknowledgeRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "ack_ids",
+            "type": "Sequence[str]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "acknowledge"
       },
+      "description": "Sample for Acknowledge",
       "file": "pubsub_v1_generated_subscriber_acknowledge_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_Acknowledge_async",
       "segments": [
         {
@@ -1368,18 +2500,57 @@
           "end": 44,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_acknowledge_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.acknowledge",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.Acknowledge",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "Acknowledge"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.AcknowledgeRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "ack_ids",
+            "type": "Sequence[str]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "acknowledge"
       },
+      "description": "Sample for Acknowledge",
       "file": "pubsub_v1_generated_subscriber_acknowledge_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_Acknowledge_sync",
       "segments": [
         {
@@ -1410,19 +2581,59 @@
           "end": 44,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_acknowledge_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.create_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.CreateSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "CreateSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.CreateSnapshotRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Snapshot",
+        "shortName": "create_snapshot"
       },
+      "description": "Sample for CreateSnapshot",
       "file": "pubsub_v1_generated_subscriber_create_snapshot_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_CreateSnapshot_async",
       "segments": [
         {
@@ -1455,18 +2666,58 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_create_snapshot_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.create_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.CreateSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "CreateSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.CreateSnapshotRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Snapshot",
+        "shortName": "create_snapshot"
       },
+      "description": "Sample for CreateSnapshot",
       "file": "pubsub_v1_generated_subscriber_create_snapshot_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_CreateSnapshot_sync",
       "segments": [
         {
@@ -1499,19 +2750,67 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_create_snapshot_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.create_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.CreateSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "CreateSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.Subscription"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "push_config",
+            "type": "google.pubsub_v1.types.PushConfig"
+          },
+          {
+            "name": "ack_deadline_seconds",
+            "type": "int"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Subscription",
+        "shortName": "create_subscription"
       },
+      "description": "Sample for CreateSubscription",
       "file": "pubsub_v1_generated_subscriber_create_subscription_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_CreateSubscription_async",
       "segments": [
         {
@@ -1544,18 +2843,66 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_create_subscription_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.create_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.CreateSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "CreateSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.Subscription"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "topic",
+            "type": "str"
+          },
+          {
+            "name": "push_config",
+            "type": "google.pubsub_v1.types.PushConfig"
+          },
+          {
+            "name": "ack_deadline_seconds",
+            "type": "int"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Subscription",
+        "shortName": "create_subscription"
       },
+      "description": "Sample for CreateSubscription",
       "file": "pubsub_v1_generated_subscriber_create_subscription_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_CreateSubscription_sync",
       "segments": [
         {
@@ -1588,19 +2935,54 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_create_subscription_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.delete_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.DeleteSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "DeleteSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteSnapshotRequest"
+          },
+          {
+            "name": "snapshot",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_snapshot"
       },
+      "description": "Sample for DeleteSnapshot",
       "file": "pubsub_v1_generated_subscriber_delete_snapshot_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_DeleteSnapshot_async",
       "segments": [
         {
@@ -1631,18 +3013,53 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_delete_snapshot_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.delete_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.DeleteSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "DeleteSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteSnapshotRequest"
+          },
+          {
+            "name": "snapshot",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_snapshot"
       },
+      "description": "Sample for DeleteSnapshot",
       "file": "pubsub_v1_generated_subscriber_delete_snapshot_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_DeleteSnapshot_sync",
       "segments": [
         {
@@ -1673,19 +3090,54 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_delete_snapshot_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.delete_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.DeleteSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "DeleteSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteSubscriptionRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_subscription"
       },
+      "description": "Sample for DeleteSubscription",
       "file": "pubsub_v1_generated_subscriber_delete_subscription_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_DeleteSubscription_async",
       "segments": [
         {
@@ -1716,18 +3168,53 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_delete_subscription_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.delete_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.DeleteSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "DeleteSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.DeleteSubscriptionRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "delete_subscription"
       },
+      "description": "Sample for DeleteSubscription",
       "file": "pubsub_v1_generated_subscriber_delete_subscription_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_DeleteSubscription_sync",
       "segments": [
         {
@@ -1758,19 +3245,55 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_delete_subscription_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.get_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.GetSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "GetSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetSnapshotRequest"
+          },
+          {
+            "name": "snapshot",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Snapshot",
+        "shortName": "get_snapshot"
       },
+      "description": "Sample for GetSnapshot",
       "file": "pubsub_v1_generated_subscriber_get_snapshot_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_GetSnapshot_async",
       "segments": [
         {
@@ -1803,18 +3326,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_get_snapshot_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.get_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.GetSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "GetSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetSnapshotRequest"
+          },
+          {
+            "name": "snapshot",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Snapshot",
+        "shortName": "get_snapshot"
       },
+      "description": "Sample for GetSnapshot",
       "file": "pubsub_v1_generated_subscriber_get_snapshot_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_GetSnapshot_sync",
       "segments": [
         {
@@ -1847,19 +3406,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_get_snapshot_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.get_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.GetSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "GetSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetSubscriptionRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Subscription",
+        "shortName": "get_subscription"
       },
+      "description": "Sample for GetSubscription",
       "file": "pubsub_v1_generated_subscriber_get_subscription_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_GetSubscription_async",
       "segments": [
         {
@@ -1892,18 +3487,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_get_subscription_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.get_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.GetSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "GetSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.GetSubscriptionRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Subscription",
+        "shortName": "get_subscription"
       },
+      "description": "Sample for GetSubscription",
       "file": "pubsub_v1_generated_subscriber_get_subscription_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_GetSubscription_sync",
       "segments": [
         {
@@ -1936,19 +3567,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_get_subscription_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.list_snapshots",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ListSnapshots",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ListSnapshots"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListSnapshotsRequest"
+          },
+          {
+            "name": "project",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager",
+        "shortName": "list_snapshots"
       },
+      "description": "Sample for ListSnapshots",
       "file": "pubsub_v1_generated_subscriber_list_snapshots_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ListSnapshots_async",
       "segments": [
         {
@@ -1981,18 +3648,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_list_snapshots_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.list_snapshots",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ListSnapshots",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ListSnapshots"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListSnapshotsRequest"
+          },
+          {
+            "name": "project",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager",
+        "shortName": "list_snapshots"
       },
+      "description": "Sample for ListSnapshots",
       "file": "pubsub_v1_generated_subscriber_list_snapshots_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ListSnapshots_sync",
       "segments": [
         {
@@ -2025,19 +3728,55 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_list_snapshots_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.list_subscriptions",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ListSubscriptions",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ListSubscriptions"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListSubscriptionsRequest"
+          },
+          {
+            "name": "project",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager",
+        "shortName": "list_subscriptions"
       },
+      "description": "Sample for ListSubscriptions",
       "file": "pubsub_v1_generated_subscriber_list_subscriptions_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ListSubscriptions_async",
       "segments": [
         {
@@ -2070,18 +3809,54 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_list_subscriptions_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.list_subscriptions",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ListSubscriptions",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ListSubscriptions"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ListSubscriptionsRequest"
+          },
+          {
+            "name": "project",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager",
+        "shortName": "list_subscriptions"
       },
+      "description": "Sample for ListSubscriptions",
       "file": "pubsub_v1_generated_subscriber_list_subscriptions_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ListSubscriptions_sync",
       "segments": [
         {
@@ -2114,19 +3889,62 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_list_subscriptions_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.modify_ack_deadline",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ModifyAckDeadline",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ModifyAckDeadline"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ModifyAckDeadlineRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "ack_ids",
+            "type": "Sequence[str]"
+          },
+          {
+            "name": "ack_deadline_seconds",
+            "type": "int"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "modify_ack_deadline"
       },
+      "description": "Sample for ModifyAckDeadline",
       "file": "pubsub_v1_generated_subscriber_modify_ack_deadline_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ModifyAckDeadline_async",
       "segments": [
         {
@@ -2157,18 +3975,61 @@
           "end": 45,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_modify_ack_deadline_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.modify_ack_deadline",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ModifyAckDeadline",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ModifyAckDeadline"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ModifyAckDeadlineRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "ack_ids",
+            "type": "Sequence[str]"
+          },
+          {
+            "name": "ack_deadline_seconds",
+            "type": "int"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "modify_ack_deadline"
       },
+      "description": "Sample for ModifyAckDeadline",
       "file": "pubsub_v1_generated_subscriber_modify_ack_deadline_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ModifyAckDeadline_sync",
       "segments": [
         {
@@ -2199,19 +4060,58 @@
           "end": 45,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_modify_ack_deadline_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.modify_push_config",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ModifyPushConfig",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ModifyPushConfig"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ModifyPushConfigRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "push_config",
+            "type": "google.pubsub_v1.types.PushConfig"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "modify_push_config"
       },
+      "description": "Sample for ModifyPushConfig",
       "file": "pubsub_v1_generated_subscriber_modify_push_config_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ModifyPushConfig_async",
       "segments": [
         {
@@ -2242,18 +4142,57 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_modify_push_config_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.modify_push_config",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.ModifyPushConfig",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "ModifyPushConfig"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.ModifyPushConfigRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "push_config",
+            "type": "google.pubsub_v1.types.PushConfig"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "shortName": "modify_push_config"
       },
+      "description": "Sample for ModifyPushConfig",
       "file": "pubsub_v1_generated_subscriber_modify_push_config_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_ModifyPushConfig_sync",
       "segments": [
         {
@@ -2284,19 +4223,63 @@
           "end": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_modify_push_config_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.pull",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.Pull",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "Pull"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.PullRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "return_immediately",
+            "type": "bool"
+          },
+          {
+            "name": "max_messages",
+            "type": "int"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.PullResponse",
+        "shortName": "pull"
       },
+      "description": "Sample for Pull",
       "file": "pubsub_v1_generated_subscriber_pull_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_Pull_async",
       "segments": [
         {
@@ -2329,18 +4312,62 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_pull_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.pull",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.Pull",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "Pull"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.PullRequest"
+          },
+          {
+            "name": "subscription",
+            "type": "str"
+          },
+          {
+            "name": "return_immediately",
+            "type": "bool"
+          },
+          {
+            "name": "max_messages",
+            "type": "int"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.PullResponse",
+        "shortName": "pull"
       },
+      "description": "Sample for Pull",
       "file": "pubsub_v1_generated_subscriber_pull_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_Pull_sync",
       "segments": [
         {
@@ -2373,19 +4400,51 @@
           "start": 43,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_pull_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.seek",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.Seek",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "Seek"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.SeekRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.SeekResponse",
+        "shortName": "seek"
       },
+      "description": "Sample for Seek",
       "file": "pubsub_v1_generated_subscriber_seek_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_Seek_async",
       "segments": [
         {
@@ -2418,18 +4477,50 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_seek_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.seek",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.Seek",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "Seek"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.SeekRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.SeekResponse",
+        "shortName": "seek"
       },
+      "description": "Sample for Seek",
       "file": "pubsub_v1_generated_subscriber_seek_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_Seek_sync",
       "segments": [
         {
@@ -2462,19 +4553,51 @@
           "start": 42,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_seek_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.streaming_pull",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.StreamingPull",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "StreamingPull"
-        }
+        },
+        "parameters": [
+          {
+            "name": "requests",
+            "type": "Iterator[google.pubsub_v1.types.StreamingPullRequest]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "Iterable[google.pubsub_v1.types.StreamingPullResponse]",
+        "shortName": "streaming_pull"
       },
+      "description": "Sample for StreamingPull",
       "file": "pubsub_v1_generated_subscriber_streaming_pull_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_StreamingPull_async",
       "segments": [
         {
@@ -2507,18 +4630,50 @@
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_streaming_pull_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.streaming_pull",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.StreamingPull",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "StreamingPull"
-        }
+        },
+        "parameters": [
+          {
+            "name": "requests",
+            "type": "Iterator[google.pubsub_v1.types.StreamingPullRequest]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "Iterable[google.pubsub_v1.types.StreamingPullResponse]",
+        "shortName": "streaming_pull"
       },
+      "description": "Sample for StreamingPull",
       "file": "pubsub_v1_generated_subscriber_streaming_pull_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_StreamingPull_sync",
       "segments": [
         {
@@ -2551,19 +4706,51 @@
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_streaming_pull_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.update_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.UpdateSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "UpdateSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.UpdateSnapshotRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Snapshot",
+        "shortName": "update_snapshot"
       },
+      "description": "Sample for UpdateSnapshot",
       "file": "pubsub_v1_generated_subscriber_update_snapshot_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_UpdateSnapshot_async",
       "segments": [
         {
@@ -2596,18 +4783,50 @@
           "start": 41,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_update_snapshot_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.update_snapshot",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.UpdateSnapshot",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "UpdateSnapshot"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.UpdateSnapshotRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Snapshot",
+        "shortName": "update_snapshot"
       },
+      "description": "Sample for UpdateSnapshot",
       "file": "pubsub_v1_generated_subscriber_update_snapshot_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_UpdateSnapshot_sync",
       "segments": [
         {
@@ -2640,19 +4859,51 @@
           "start": 41,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_update_snapshot_sync.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
         "async": true,
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberAsyncClient",
+          "shortName": "SubscriberAsyncClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberAsyncClient.update_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.UpdateSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "UpdateSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.UpdateSubscriptionRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Subscription",
+        "shortName": "update_subscription"
       },
+      "description": "Sample for UpdateSubscription",
       "file": "pubsub_v1_generated_subscriber_update_subscription_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_UpdateSubscription_async",
       "segments": [
         {
@@ -2685,18 +4936,50 @@
           "start": 46,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_update_subscription_async.py"
     },
     {
+      "canonical": true,
       "clientMethod": {
+        "client": {
+          "fullName": "google.pubsub_v1.SubscriberClient",
+          "shortName": "SubscriberClient"
+        },
+        "fullName": "google.pubsub_v1.SubscriberClient.update_subscription",
         "method": {
+          "fullName": "google.pubsub.v1.Subscriber.UpdateSubscription",
           "service": {
+            "fullName": "google.pubsub.v1.Subscriber",
             "shortName": "Subscriber"
           },
           "shortName": "UpdateSubscription"
-        }
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.pubsub_v1.types.UpdateSubscriptionRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.pubsub_v1.types.Subscription",
+        "shortName": "update_subscription"
       },
+      "description": "Sample for UpdateSubscription",
       "file": "pubsub_v1_generated_subscriber_update_subscription_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
       "regionTag": "pubsub_v1_generated_Subscriber_UpdateSubscription_sync",
       "segments": [
         {
@@ -2729,7 +5012,8 @@
           "start": 46,
           "type": "RESPONSE_HANDLING"
         }
-      ]
+      ],
+      "title": "pubsub_v1_generated_subscriber_update_subscription_sync.py"
     }
   ]
 }

--- a/samples/snippets/subscriber.py
+++ b/samples/snippets/subscriber.py
@@ -614,7 +614,10 @@ def receive_messages_with_blocking_shutdown(
 def receive_messages_with_exactly_once_delivery_enabled(
     project_id: str, subscription_id: str, timeout: Optional[float] = None
 ) -> None:
-    """Receives messages from a pull subscription with exactly-once delivery enabled."""
+    """Receives messages from a pull subscription with exactly-once delivery enabled.
+    This is a preview feature. For more details, see:
+    https://cloud.google.com/pubsub/docs/exactly-once-delivery."
+    """
     # [START pubsub_subscriber_exactly_once]
     from concurrent.futures import TimeoutError
     from google.cloud import pubsub_v1

--- a/samples/snippets/subscriber_test.py
+++ b/samples/snippets/subscriber_test.py
@@ -51,6 +51,7 @@ FILTER = 'attributes.author="unknown"'
 C = TypeVar("C", bound=Callable[..., Any])
 
 typed_flaky = cast(Callable[[C], C], flaky(max_runs=3, min_passes=1))
+typed_super_flaky = cast(Callable[[C], C], flaky(max_runs=10, min_passes=10))
 
 
 @pytest.fixture(scope="module")
@@ -704,6 +705,7 @@ def test_receive_with_blocking_shutdown(
     eventually_consistent_test()
 
 
+@typed_super_flaky
 def test_receive_messages_with_exactly_once_delivery_enabled(
     regional_publisher_client: pubsub_v1.PublisherClient,
     exactly_once_delivery_topic: str,
@@ -711,26 +713,18 @@ def test_receive_messages_with_exactly_once_delivery_enabled(
     capsys: CaptureFixture[str],
 ) -> None:
 
-    typed_backoff = cast(
-        Callable[[C], C], backoff.on_exception(backoff.expo, Unknown, max_time=300),
+    message_ids = _publish_messages(
+        regional_publisher_client, exactly_once_delivery_topic
     )
 
-    @typed_backoff
-    def eventually_consistent_test() -> None:
-        message_ids = _publish_messages(
-            regional_publisher_client, exactly_once_delivery_topic
-        )
+    subscriber.receive_messages_with_exactly_once_delivery_enabled(
+        PROJECT_ID, SUBSCRIPTION_EOD, 200
+    )
 
-        subscriber.receive_messages_with_exactly_once_delivery_enabled(
-            PROJECT_ID, SUBSCRIPTION_EOD, 10
-        )
-
-        out, _ = capsys.readouterr()
-        assert subscription_eod in out
-        for message_id in message_ids:
-            assert message_id in out
-
-    eventually_consistent_test()
+    out, _ = capsys.readouterr()
+    assert subscription_eod in out
+    for message_id in message_ids:
+        assert message_id in out
 
 
 def test_listen_for_errors(

--- a/tests/unit/gapic/pubsub_v1/test_publisher.py
+++ b/tests/unit/gapic/pubsub_v1/test_publisher.py
@@ -87,24 +87,24 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class",
+    "client_class,transport_name",
     [
-        PublisherClient,
-        PublisherAsyncClient,
+        (PublisherClient, "grpc"),
+        (PublisherAsyncClient, "grpc_asyncio"),
     ],
 )
-def test_publisher_client_from_service_account_info(client_class):
+def test_publisher_client_from_service_account_info(client_class, transport_name):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_info"
     ) as factory:
         factory.return_value = creds
         info = {"valid": True}
-        client = client_class.from_service_account_info(info)
+        client = client_class.from_service_account_info(info, transport=transport_name)
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "pubsub.googleapis.com:443"
+        assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
 @pytest.mark.parametrize(
@@ -133,27 +133,31 @@ def test_publisher_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class",
+    "client_class,transport_name",
     [
-        PublisherClient,
-        PublisherAsyncClient,
+        (PublisherClient, "grpc"),
+        (PublisherAsyncClient, "grpc_asyncio"),
     ],
 )
-def test_publisher_client_from_service_account_file(client_class):
+def test_publisher_client_from_service_account_file(client_class, transport_name):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_file"
     ) as factory:
         factory.return_value = creds
-        client = client_class.from_service_account_file("dummy/file/path.json")
+        client = client_class.from_service_account_file(
+            "dummy/file/path.json", transport=transport_name
+        )
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        client = client_class.from_service_account_json("dummy/file/path.json")
+        client = client_class.from_service_account_json(
+            "dummy/file/path.json", transport=transport_name
+        )
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "pubsub.googleapis.com:443"
+        assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
 def test_publisher_client_get_transport_class():
@@ -1862,7 +1866,7 @@ async def test_list_topics_async_pager():
         )
         assert async_pager.next_page_token == "abc"
         responses = []
-        async for response in async_pager:
+        async for response in async_pager:  # pragma: no branch
             responses.append(response)
 
         assert len(responses) == 6
@@ -1908,7 +1912,9 @@ async def test_list_topics_async_pages():
             RuntimeError,
         )
         pages = []
-        async for page_ in (await client.list_topics(request={})).pages:
+        async for page_ in (
+            await client.list_topics(request={})
+        ).pages:  # pragma: no branch
             pages.append(page_)
         for page_, token in zip(pages, ["abc", "def", "ghi", ""]):
             assert page_.raw_page.next_page_token == token
@@ -2304,7 +2310,7 @@ async def test_list_topic_subscriptions_async_pager():
         )
         assert async_pager.next_page_token == "abc"
         responses = []
-        async for response in async_pager:
+        async for response in async_pager:  # pragma: no branch
             responses.append(response)
 
         assert len(responses) == 6
@@ -2352,7 +2358,9 @@ async def test_list_topic_subscriptions_async_pages():
             RuntimeError,
         )
         pages = []
-        async for page_ in (await client.list_topic_subscriptions(request={})).pages:
+        async for page_ in (
+            await client.list_topic_subscriptions(request={})
+        ).pages:  # pragma: no branch
             pages.append(page_)
         for page_, token in zip(pages, ["abc", "def", "ghi", ""]):
             assert page_.raw_page.next_page_token == token
@@ -2748,7 +2756,7 @@ async def test_list_topic_snapshots_async_pager():
         )
         assert async_pager.next_page_token == "abc"
         responses = []
-        async for response in async_pager:
+        async for response in async_pager:  # pragma: no branch
             responses.append(response)
 
         assert len(responses) == 6
@@ -2796,7 +2804,9 @@ async def test_list_topic_snapshots_async_pages():
             RuntimeError,
         )
         pages = []
-        async for page_ in (await client.list_topic_snapshots(request={})).pages:
+        async for page_ in (
+            await client.list_topic_snapshots(request={})
+        ).pages:  # pragma: no branch
             pages.append(page_)
         for page_, token in zip(pages, ["abc", "def", "ghi", ""]):
             assert page_.raw_page.next_page_token == token
@@ -3267,6 +3277,19 @@ def test_transport_adc(transport_class):
         adc.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+    ],
+)
+def test_transport_kind(transport_name):
+    transport = PublisherClient.get_transport_class(transport_name)(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = PublisherClient(
@@ -3319,6 +3342,14 @@ def test_publisher_base_transport():
 
     with pytest.raises(NotImplementedError):
         transport.close()
+
+    # Catch all for all remaining methods and properties
+    remainder = [
+        "kind",
+    ]
+    for r in remainder:
+        with pytest.raises(NotImplementedError):
+            getattr(transport, r)()
 
 
 def test_publisher_base_transport_with_credentials_file():
@@ -3478,24 +3509,40 @@ def test_publisher_grpc_transport_client_cert_source_for_mtls(transport_class):
             )
 
 
-def test_publisher_host_no_port():
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+    ],
+)
+def test_publisher_host_no_port(transport_name):
     client = PublisherClient(
         credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="pubsub.googleapis.com"
         ),
+        transport=transport_name,
     )
-    assert client.transport._host == "pubsub.googleapis.com:443"
+    assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
-def test_publisher_host_with_port():
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+    ],
+)
+def test_publisher_host_with_port(transport_name):
     client = PublisherClient(
         credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="pubsub.googleapis.com:8000"
         ),
+        transport=transport_name,
     )
-    assert client.transport._host == "pubsub.googleapis.com:8000"
+    assert client.transport._host == ("pubsub.googleapis.com:8000")
 
 
 def test_publisher_grpc_transport_channel():
@@ -3815,6 +3862,20 @@ def test_client_with_default_client_info():
         prep.assert_called_once_with(client_info)
 
 
+@pytest.mark.asyncio
+async def test_transport_close_async():
+    client = PublisherAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
+    )
+    with mock.patch.object(
+        type(getattr(client.transport, "grpc_channel")), "close"
+    ) as close:
+        async with client:
+            close.assert_not_called()
+        close.assert_called_once()
+
+
 def test_set_iam_policy(transport: str = "grpc"):
     client = PublisherClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -3832,9 +3893,7 @@ def test_set_iam_policy(transport: str = "grpc"):
             version=774,
             etag=b"etag_blob",
         )
-
         response = client.set_iam_policy(request)
-
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
@@ -3863,17 +3922,16 @@ async def test_set_iam_policy_async(transport: str = "grpc_asyncio"):
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
+        # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             policy_pb2.Policy(
                 version=774,
                 etag=b"etag_blob",
             )
         )
-
         response = await client.set_iam_policy(request)
-
         # Establish that the underlying gRPC stub method was called.
-        assert len(call.mock_calls)
+        assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
 
         assert args[0] == request
@@ -3933,7 +3991,7 @@ async def test_set_iam_policy_field_headers_async():
         await client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert len(call.mock_calls)
+        assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
         assert args[0] == request
 
@@ -4324,20 +4382,6 @@ async def test_test_iam_permissions_from_dict_async():
             }
         )
         call.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_transport_close_async():
-    client = PublisherAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="grpc_asyncio",
-    )
-    with mock.patch.object(
-        type(getattr(client.transport, "grpc_channel")), "close"
-    ) as close:
-        async with client:
-            close.assert_not_called()
-        close.assert_called_once()
 
 
 def test_transport_close():

--- a/tests/unit/gapic/pubsub_v1/test_schema_service.py
+++ b/tests/unit/gapic/pubsub_v1/test_schema_service.py
@@ -89,24 +89,24 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class",
+    "client_class,transport_name",
     [
-        SchemaServiceClient,
-        SchemaServiceAsyncClient,
+        (SchemaServiceClient, "grpc"),
+        (SchemaServiceAsyncClient, "grpc_asyncio"),
     ],
 )
-def test_schema_service_client_from_service_account_info(client_class):
+def test_schema_service_client_from_service_account_info(client_class, transport_name):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_info"
     ) as factory:
         factory.return_value = creds
         info = {"valid": True}
-        client = client_class.from_service_account_info(info)
+        client = client_class.from_service_account_info(info, transport=transport_name)
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "pubsub.googleapis.com:443"
+        assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
 @pytest.mark.parametrize(
@@ -135,27 +135,31 @@ def test_schema_service_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class",
+    "client_class,transport_name",
     [
-        SchemaServiceClient,
-        SchemaServiceAsyncClient,
+        (SchemaServiceClient, "grpc"),
+        (SchemaServiceAsyncClient, "grpc_asyncio"),
     ],
 )
-def test_schema_service_client_from_service_account_file(client_class):
+def test_schema_service_client_from_service_account_file(client_class, transport_name):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_file"
     ) as factory:
         factory.return_value = creds
-        client = client_class.from_service_account_file("dummy/file/path.json")
+        client = client_class.from_service_account_file(
+            "dummy/file/path.json", transport=transport_name
+        )
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        client = client_class.from_service_account_json("dummy/file/path.json")
+        client = client_class.from_service_account_json(
+            "dummy/file/path.json", transport=transport_name
+        )
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "pubsub.googleapis.com:443"
+        assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
 def test_schema_service_client_get_transport_class():
@@ -1508,7 +1512,7 @@ async def test_list_schemas_async_pager():
         )
         assert async_pager.next_page_token == "abc"
         responses = []
-        async for response in async_pager:
+        async for response in async_pager:  # pragma: no branch
             responses.append(response)
 
         assert len(responses) == 6
@@ -1554,7 +1558,9 @@ async def test_list_schemas_async_pages():
             RuntimeError,
         )
         pages = []
-        async for page_ in (await client.list_schemas(request={})).pages:
+        async for page_ in (
+            await client.list_schemas(request={})
+        ).pages:  # pragma: no branch
             pages.append(page_)
         for page_, token in zip(pages, ["abc", "def", "ghi", ""]):
             assert page_.raw_page.next_page_token == token
@@ -2251,6 +2257,19 @@ def test_transport_adc(transport_class):
         adc.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+    ],
+)
+def test_transport_kind(transport_name):
+    transport = SchemaServiceClient.get_transport_class(transport_name)(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = SchemaServiceClient(
@@ -2300,6 +2319,14 @@ def test_schema_service_base_transport():
 
     with pytest.raises(NotImplementedError):
         transport.close()
+
+    # Catch all for all remaining methods and properties
+    remainder = [
+        "kind",
+    ]
+    for r in remainder:
+        with pytest.raises(NotImplementedError):
+            getattr(transport, r)()
 
 
 def test_schema_service_base_transport_with_credentials_file():
@@ -2462,24 +2489,40 @@ def test_schema_service_grpc_transport_client_cert_source_for_mtls(transport_cla
             )
 
 
-def test_schema_service_host_no_port():
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+    ],
+)
+def test_schema_service_host_no_port(transport_name):
     client = SchemaServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="pubsub.googleapis.com"
         ),
+        transport=transport_name,
     )
-    assert client.transport._host == "pubsub.googleapis.com:443"
+    assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
-def test_schema_service_host_with_port():
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+    ],
+)
+def test_schema_service_host_with_port(transport_name):
     client = SchemaServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="pubsub.googleapis.com:8000"
         ),
+        transport=transport_name,
     )
-    assert client.transport._host == "pubsub.googleapis.com:8000"
+    assert client.transport._host == ("pubsub.googleapis.com:8000")
 
 
 def test_schema_service_grpc_transport_channel():
@@ -2759,6 +2802,20 @@ def test_client_with_default_client_info():
         prep.assert_called_once_with(client_info)
 
 
+@pytest.mark.asyncio
+async def test_transport_close_async():
+    client = SchemaServiceAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
+    )
+    with mock.patch.object(
+        type(getattr(client.transport, "grpc_channel")), "close"
+    ) as close:
+        async with client:
+            close.assert_not_called()
+        close.assert_called_once()
+
+
 def test_set_iam_policy(transport: str = "grpc"):
     client = SchemaServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -2776,9 +2833,7 @@ def test_set_iam_policy(transport: str = "grpc"):
             version=774,
             etag=b"etag_blob",
         )
-
         response = client.set_iam_policy(request)
-
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
@@ -2807,17 +2862,16 @@ async def test_set_iam_policy_async(transport: str = "grpc_asyncio"):
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
+        # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             policy_pb2.Policy(
                 version=774,
                 etag=b"etag_blob",
             )
         )
-
         response = await client.set_iam_policy(request)
-
         # Establish that the underlying gRPC stub method was called.
-        assert len(call.mock_calls)
+        assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
 
         assert args[0] == request
@@ -2877,7 +2931,7 @@ async def test_set_iam_policy_field_headers_async():
         await client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert len(call.mock_calls)
+        assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
         assert args[0] == request
 
@@ -3268,20 +3322,6 @@ async def test_test_iam_permissions_from_dict_async():
             }
         )
         call.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_transport_close_async():
-    client = SchemaServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="grpc_asyncio",
-    )
-    with mock.patch.object(
-        type(getattr(client.transport, "grpc_channel")), "close"
-    ) as close:
-        async with client:
-            close.assert_not_called()
-        close.assert_called_once()
 
 
 def test_transport_close():

--- a/tests/unit/gapic/pubsub_v1/test_subscriber.py
+++ b/tests/unit/gapic/pubsub_v1/test_subscriber.py
@@ -89,24 +89,24 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class",
+    "client_class,transport_name",
     [
-        SubscriberClient,
-        SubscriberAsyncClient,
+        (SubscriberClient, "grpc"),
+        (SubscriberAsyncClient, "grpc_asyncio"),
     ],
 )
-def test_subscriber_client_from_service_account_info(client_class):
+def test_subscriber_client_from_service_account_info(client_class, transport_name):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_info"
     ) as factory:
         factory.return_value = creds
         info = {"valid": True}
-        client = client_class.from_service_account_info(info)
+        client = client_class.from_service_account_info(info, transport=transport_name)
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "pubsub.googleapis.com:443"
+        assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
 @pytest.mark.parametrize(
@@ -135,27 +135,31 @@ def test_subscriber_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class",
+    "client_class,transport_name",
     [
-        SubscriberClient,
-        SubscriberAsyncClient,
+        (SubscriberClient, "grpc"),
+        (SubscriberAsyncClient, "grpc_asyncio"),
     ],
 )
-def test_subscriber_client_from_service_account_file(client_class):
+def test_subscriber_client_from_service_account_file(client_class, transport_name):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_file"
     ) as factory:
         factory.return_value = creds
-        client = client_class.from_service_account_file("dummy/file/path.json")
+        client = client_class.from_service_account_file(
+            "dummy/file/path.json", transport=transport_name
+        )
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        client = client_class.from_service_account_json("dummy/file/path.json")
+        client = client_class.from_service_account_json(
+            "dummy/file/path.json", transport=transport_name
+        )
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "pubsub.googleapis.com:443"
+        assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
 def test_subscriber_client_get_transport_class():
@@ -1758,7 +1762,7 @@ async def test_list_subscriptions_async_pager():
         )
         assert async_pager.next_page_token == "abc"
         responses = []
-        async for response in async_pager:
+        async for response in async_pager:  # pragma: no branch
             responses.append(response)
 
         assert len(responses) == 6
@@ -1806,7 +1810,9 @@ async def test_list_subscriptions_async_pages():
             RuntimeError,
         )
         pages = []
-        async for page_ in (await client.list_subscriptions(request={})).pages:
+        async for page_ in (
+            await client.list_subscriptions(request={})
+        ).pages:  # pragma: no branch
             pages.append(page_)
         for page_, token in zip(pages, ["abc", "def", "ghi", ""]):
             assert page_.raw_page.next_page_token == token
@@ -3688,7 +3694,7 @@ async def test_list_snapshots_async_pager():
         )
         assert async_pager.next_page_token == "abc"
         responses = []
-        async for response in async_pager:
+        async for response in async_pager:  # pragma: no branch
             responses.append(response)
 
         assert len(responses) == 6
@@ -3734,7 +3740,9 @@ async def test_list_snapshots_async_pages():
             RuntimeError,
         )
         pages = []
-        async for page_ in (await client.list_snapshots(request={})).pages:
+        async for page_ in (
+            await client.list_snapshots(request={})
+        ).pages:  # pragma: no branch
             pages.append(page_)
         for page_, token in zip(pages, ["abc", "def", "ghi", ""]):
             assert page_.raw_page.next_page_token == token
@@ -4585,6 +4593,19 @@ def test_transport_adc(transport_class):
         adc.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+    ],
+)
+def test_transport_kind(transport_name):
+    transport = SubscriberClient.get_transport_class(transport_name)(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = SubscriberClient(
@@ -4644,6 +4665,14 @@ def test_subscriber_base_transport():
 
     with pytest.raises(NotImplementedError):
         transport.close()
+
+    # Catch all for all remaining methods and properties
+    remainder = [
+        "kind",
+    ]
+    for r in remainder:
+        with pytest.raises(NotImplementedError):
+            getattr(transport, r)()
 
 
 def test_subscriber_base_transport_with_credentials_file():
@@ -4803,24 +4832,40 @@ def test_subscriber_grpc_transport_client_cert_source_for_mtls(transport_class):
             )
 
 
-def test_subscriber_host_no_port():
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+    ],
+)
+def test_subscriber_host_no_port(transport_name):
     client = SubscriberClient(
         credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="pubsub.googleapis.com"
         ),
+        transport=transport_name,
     )
-    assert client.transport._host == "pubsub.googleapis.com:443"
+    assert client.transport._host == ("pubsub.googleapis.com:443")
 
 
-def test_subscriber_host_with_port():
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+    ],
+)
+def test_subscriber_host_with_port(transport_name):
     client = SubscriberClient(
         credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="pubsub.googleapis.com:8000"
         ),
+        transport=transport_name,
     )
-    assert client.transport._host == "pubsub.googleapis.com:8000"
+    assert client.transport._host == ("pubsub.googleapis.com:8000")
 
 
 def test_subscriber_grpc_transport_channel():
@@ -5140,6 +5185,20 @@ def test_client_with_default_client_info():
         prep.assert_called_once_with(client_info)
 
 
+@pytest.mark.asyncio
+async def test_transport_close_async():
+    client = SubscriberAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
+    )
+    with mock.patch.object(
+        type(getattr(client.transport, "grpc_channel")), "close"
+    ) as close:
+        async with client:
+            close.assert_not_called()
+        close.assert_called_once()
+
+
 def test_set_iam_policy(transport: str = "grpc"):
     client = SubscriberClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -5157,9 +5216,7 @@ def test_set_iam_policy(transport: str = "grpc"):
             version=774,
             etag=b"etag_blob",
         )
-
         response = client.set_iam_policy(request)
-
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
@@ -5188,17 +5245,16 @@ async def test_set_iam_policy_async(transport: str = "grpc_asyncio"):
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
+        # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             policy_pb2.Policy(
                 version=774,
                 etag=b"etag_blob",
             )
         )
-
         response = await client.set_iam_policy(request)
-
         # Establish that the underlying gRPC stub method was called.
-        assert len(call.mock_calls)
+        assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
 
         assert args[0] == request
@@ -5258,7 +5314,7 @@ async def test_set_iam_policy_field_headers_async():
         await client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert len(call.mock_calls)
+        assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
         assert args[0] == request
 
@@ -5649,20 +5705,6 @@ async def test_test_iam_permissions_from_dict_async():
             }
         )
         call.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_transport_close_async():
-    client = SubscriberAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="grpc_asyncio",
-    )
-    with mock.patch.object(
-        type(getattr(client.transport, "grpc_channel")), "close"
-    ) as close:
-        async with client:
-            close.assert_not_called()
-        close.assert_called_once()
 
 
 def test_transport_close():


### PR DESCRIPTION
Add comments to sample, as well as edit docstrings for ack, ack_with_response, modify ack deadline, and nack_with_response linking to exactly once delivery documentation.

Also swapped exactly once delivery NOT enabled descriptions to come first, so that the default case is shown first.

Fixes #617  🦕
