### PR TITLE
fix: Update stream_ack_deadline with ack_deadline

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -413,7 +413,8 @@ class StreamingPullManager(object):
                 self._ack_deadline = max(
                     self._ack_deadline, _MIN_ACK_DEADLINE_SECS_WHEN_EXACTLY_ONCE_ENABLED
                 )
-
+            # Set the _stream_ack_deadline to match the new ack_deadline
+            self._stream_ack_deadline = self._ack_deadline
             return self._ack_deadline
 
     @property

--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -451,8 +451,10 @@ class StreamingPullManager(object):
                 self._ack_deadline = max(
                     self._ack_deadline, _MIN_ACK_DEADLINE_SECS_WHEN_EXACTLY_ONCE_ENABLED
                 )
-            # Set the _stream_ack_deadline to match the new ack_deadline
-            self._stream_ack_deadline = self._ack_deadline
+            # If we have updated the ack_deadline and it is longer than the stream_ack_deadline
+            # set the stream_ack_deadline to the new ack_deadline.
+            if self._ack_deadline > self._stream_ack_deadline:
+                self._stream_ack_deadline = self._ack_deadline
             return self._ack_deadline
 
     @property
@@ -819,7 +821,7 @@ class StreamingPullManager(object):
         )
 
         # Create the RPC
-        stream_ack_deadline_seconds = self.ack_deadline
+        stream_ack_deadline_seconds = self._stream_ack_deadline
 
         get_initial_request = functools.partial(
             self._get_initial_request, stream_ack_deadline_seconds

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -257,6 +257,7 @@ def test__obtain_ack_deadline_with_min_duration_per_lease_extension():
     # The deadline configured in flow control should prevail.
     deadline = manager._obtain_ack_deadline(maybe_update=True)
     assert deadline == histogram.MAX_ACK_DEADLINE
+    assert manager._stream_ack_deadline == histogram.MAX_ACK_DEADLINE
 
 
 def test__obtain_ack_deadline_with_max_duration_per_lease_extension_too_low():
@@ -283,6 +284,7 @@ def test__obtain_ack_deadline_with_min_duration_per_lease_extension_too_high():
     # The deadline configured in flow control should be adjusted to the maximum allowed.
     deadline = manager._obtain_ack_deadline(maybe_update=True)
     assert deadline == histogram.MAX_ACK_DEADLINE
+    assert manager._stream_ack_deadline == histogram.MAX_ACK_DEADLINE
 
 
 def test__obtain_ack_deadline_with_exactly_once_enabled():
@@ -299,6 +301,7 @@ def test__obtain_ack_deadline_with_exactly_once_enabled():
     # Since the 60-second min ack_deadline value for exactly_once subscriptions
     # seconds is higher than the histogram value, the deadline should be 60 sec.
     assert deadline == 60
+    assert manager._stream_ack_deadline == 60
 
 
 def test__obtain_ack_deadline_with_min_duration_per_lease_extension_with_exactly_once_enabled():
@@ -316,6 +319,7 @@ def test__obtain_ack_deadline_with_min_duration_per_lease_extension_with_exactly
     # User-defined custom min ack_deadline value takes precedence over
     # exactly_once default of 60 seconds.
     assert deadline == histogram.MAX_ACK_DEADLINE
+    assert manager._stream_ack_deadline == histogram.MAX_ACK_DEADLINE
 
 
 def test__obtain_ack_deadline_no_value_update():
@@ -1148,7 +1152,7 @@ def test_open(heartbeater, dispatcher, leaser, background_consumer, resumable_bi
     )
     initial_request_arg = resumable_bidi_rpc.call_args.kwargs["initial_request"]
     assert initial_request_arg.func == manager._get_initial_request
-    assert initial_request_arg.args[0] == 18
+    assert initial_request_arg.args[0] == 60
     assert not manager._client.get_subscription.called
 
     resumable_bidi_rpc.return_value.add_done_callback.assert_called_once_with(
@@ -1833,6 +1837,7 @@ def test__on_response_disable_exactly_once():
     # exactly_once minimum since exactly_once has been disabled.
     deadline = manager._obtain_ack_deadline(maybe_update=True)
     assert deadline == histogram.MIN_ACK_DEADLINE
+    assert manager._stream_ack_deadline == 60
 
 
 def test__on_response_exactly_once_immediate_modacks_fail():


### PR DESCRIPTION
Updates stream_ack_deadline along with ack_deadline to prevent a lower stream_ack_deadline being sent on the heartbeat if the ack_deadline has been updated.
Correctly sets initial request ack_deadline_seconds to stream_ack_deadline instead of ack_deadline
Fixes #758 🦕
