### PR TITLE
fix: remove expired ack_ids

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -197,7 +197,12 @@ class Leaser(object):
                 #       is inactive.
                 assert self._manager.dispatcher is not None
                 ack_id_gen = (ack_id for ack_id in ack_ids)
-                self._manager._send_lease_modacks(ack_id_gen, deadline)
+                expired_ack_ids = self._manager._send_lease_modacks(
+                    ack_id_gen, deadline
+                )
+                if self._manager._exactly_once_delivery_enabled():
+                    for ack_id in expired_ack_ids:
+                        leased_messages.pop(ack_id)
 
             # Now wait an appropriate period of time and do this again.
             #

--- a/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -186,7 +186,6 @@ class Leaser(object):
             # Create a modack request.
             # We do not actually call `modify_ack_deadline` over and over
             # because it is more efficient to make a single request.
-            expired_ack_ids = []
             ack_ids = leased_messages.keys()
             if ack_ids:
                 _LOGGER.debug("Renewing lease for %d ack IDs.", len(ack_ids))
@@ -198,30 +197,7 @@ class Leaser(object):
                 #       is inactive.
                 assert self._manager.dispatcher is not None
                 ack_id_gen = (ack_id for ack_id in ack_ids)
-                expired_ack_ids = self._manager._send_lease_modacks(
-                    ack_id_gen, deadline
-                )
-
-            # Drop more items based on expiration:
-            if self._manager._exactly_once_delivery_enabled():
-                to_drop = [
-                    requests.DropRequest(ack_id, item.size, item.ordering_key)
-                    for ack_id, item in leased_messages.items()
-                    if ack_id in expired_ack_ids
-                ]
-                if to_drop:
-                    _LOGGER.warning(
-                        "Dropping %s items because they were leased too long.",
-                        len(to_drop),
-                    )
-                    assert self._manager.dispatcher is not None
-                    self._manager.dispatcher.drop(to_drop)
-
-                # Remove dropped items from our copy of the leased messages (they
-                # have already been removed from the real one by
-                # self._manager.drop(), which calls self.remove()).
-                for item in to_drop:
-                    leased_messages.pop(item.ack_id)
+                self._manager._send_lease_modacks(ack_id_gen, deadline)
 
             # Now wait an appropriate period of time and do this again.
             #

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1882,6 +1882,9 @@ def test__on_response_exactly_once_immediate_modacks_fail():
 
     # Actually run the method and prove that modack and schedule are called in
     # the expected way.
+    
+    fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=10)
+    
     manager._on_response(response)
 
     # The second messages should be scheduled, and not the first.
@@ -1897,10 +1900,8 @@ def test__on_response_exactly_once_immediate_modacks_fail():
     # No messages available
     assert manager._messages_on_hold.get() is None
 
-    # exactly_once should be enabled
-    manager._on_response(response)
     # do not add message
-    assert manager.load == 0
+    assert manager.load == .001
 
 
 def test__should_recover_true():

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -1882,9 +1882,9 @@ def test__on_response_exactly_once_immediate_modacks_fail():
 
     # Actually run the method and prove that modack and schedule are called in
     # the expected way.
-    
+
     fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=10)
-    
+
     manager._on_response(response)
 
     # The second messages should be scheduled, and not the first.
@@ -1901,7 +1901,7 @@ def test__on_response_exactly_once_immediate_modacks_fail():
     assert manager._messages_on_hold.get() is None
 
     # do not add message
-    assert manager.load == .001
+    assert manager.load == 0.001
 
 
 def test__should_recover_true():


### PR DESCRIPTION
When eod is enabled:
(1) Return a list of expired_ack_ids from send_lease_modacks, otherwise return an empty list
(2) In _on_response, check that a message's ack_id is not in expired_ack_ids before adding to leaser and putting the message on hold
Fixes #786 🦕 and possibly #593 
