### PR TITLE
chore: release as 2.13.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = "google-cloud-pubsub"
 description = "Google Cloud Pub/Sub API client library"
-version = "2.13.8"
+version = "2.13.9"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE

chore: release as 2.13.10

Release-As: 2.13.10
END_COMMIT_OVERRIDE


Same PR as https://github.com/googleapis/python-pubsub/pull/803 but needs the automerge label added rather than merging manually