### PR TITLE
Revert "chore(deps): update dependency mock to v5 (#837)"

### DIFF
--- a/samples/snippets/requirements-test.txt
+++ b/samples/snippets/requirements-test.txt
@@ -1,5 +1,5 @@
 backoff==2.2.1
 pytest==7.2.0
-mock==5.0.0
+mock==4.0.3
 flaky==3.7.0
 google-cloud-bigquery==3.4.1


### PR DESCRIPTION
This reverts commit 2981c8a188ccbe5614dd4baebd9be95223754f7c.

Reverting upgrade of mock v5 dependency which failed on merge
Fixes #841 🦕
