### PR TITLE
test: pin mock version to 5.0.0 in noxfile for unit tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -36,6 +36,7 @@ DEFAULT_PYTHON_VERSION = "3.8"
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
+    "mock==5.0.0",
     "asyncmock",
     "pytest",
     "pytest-cov",
@@ -50,6 +51,7 @@ UNIT_TEST_EXTRAS_BY_PYTHON = {}
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.10"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
+    "mock==5.0.0",
     "pytest",
     "google-cloud-testutils",
 ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,9 +35,7 @@ DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
-    "mock",
-    "mock==5.0.0",
-    "asyncmock",
+    "mock==5.0.0" "asyncmock",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",
@@ -50,9 +48,7 @@ UNIT_TEST_EXTRAS_BY_PYTHON = {}
 
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.10"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES = [
-    "mock",
-    "mock==5.0.0",
-    "pytest",
+    "mock==5.0.0" "pytest",
     "google-cloud-testutils",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES = [

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,8 @@ DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
-    "mock==5.0.0" "asyncmock",
+    "mock==5.0.0",
+    "asyncmock",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",
@@ -48,7 +49,8 @@ UNIT_TEST_EXTRAS_BY_PYTHON = {}
 
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.10"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES = [
-    "mock==5.0.0" "pytest",
+    "mock==5.0.0",
+    "pytest",
     "google-cloud-testutils",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES = [

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
-    "mock",
+    "mock==5.0.0",
     "asyncmock",
     "pytest",
     "pytest-cov",

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
-    "mock==5.0.0",
+    "mock",
     "asyncmock",
     "pytest",
     "pytest-cov",

--- a/owlbot.py
+++ b/owlbot.py
@@ -354,7 +354,7 @@ s.replace(
     "noxfile.py", r'"blacken",', '\g<0>\n    "mypy",',
 )
 s.replace(
-    "noxfile.py", r'"mock",', '\g<0>\n    "mock==5.0.0",',
+    "noxfile.py", r'"mock",', '"mock==5.0.0"',
 )
 s.replace(
     "noxfile.py",

--- a/owlbot.py
+++ b/owlbot.py
@@ -354,7 +354,7 @@ s.replace(
     "noxfile.py", r'"blacken",', '\g<0>\n    "mypy",',
 )
 s.replace(
-    "noxfile.py", r'"mock",', '"mock==5.0.0"',
+    "noxfile.py", r'"mock"', '"mock==5.0.0"',
 )
 s.replace(
     "noxfile.py",

--- a/owlbot.py
+++ b/owlbot.py
@@ -354,6 +354,9 @@ s.replace(
     "noxfile.py", r'"blacken",', '\g<0>\n    "mypy",',
 )
 s.replace(
+    "noxfile.py", r'"mock",', '\g<0>\n    "mock==5.0.0",',
+)
+s.replace(
     "noxfile.py",
     r"nox\.options\.error_on_missing_interpreters = True",
     textwrap.dedent(


### PR DESCRIPTION
Temporarily pinning mock version to 5.0.0 to fix resume_publish unit test.

Fixes #841  🦕
