### PR TITLE
Documentation: Improve Docstrings in modules `google/pubsub_v1/services/subscriber`

### DIFF
--- a/google/pubsub_v1/services/subscriber/async_client.py
+++ b/google/pubsub_v1/services/subscriber/async_client.py
@@ -239,8 +239,8 @@ class SubscriberAsyncClient:
         r"""Creates a subscription to a given topic. See the [resource name
         rules]
         (https://cloud.google.com/pubsub/docs/pubsub-basics#resource_names).
-        If the subscription already exists, returns ``ALREADY_EXISTS``.
-        If the corresponding topic doesn't exist, returns ``NOT_FOUND``.
+        If the subscription already exists, raises ``ALREADY_EXISTS``.
+        If the corresponding topic doesn't exist, raises ``NOT_FOUND``.
 
         If the name is not provided in the request, the server will
         assign a random name for this subscription on the same project
@@ -1795,8 +1795,8 @@ class SubscriberAsyncClient:
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-        If the snapshot already exists, returns ``ALREADY_EXISTS``. If
-        the requested subscription doesn't exist, returns ``NOT_FOUND``.
+        If the snapshot already exists, raises ``ALREADY_EXISTS``. If
+        the requested subscription doesn't exist, raises ``NOT_FOUND``.
         If the backlog in the subscription is too old -- and the
         resulting snapshot would expire in less than 1 hour -- then
         ``FAILED_PRECONDITION`` is returned. See also the

--- a/google/pubsub_v1/services/subscriber/client.py
+++ b/google/pubsub_v1/services/subscriber/client.py
@@ -520,8 +520,8 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         r"""Creates a subscription to a given topic. See the [resource name
         rules]
         (https://cloud.google.com/pubsub/docs/pubsub-basics#resource_names).
-        If the subscription already exists, returns ``ALREADY_EXISTS``.
-        If the corresponding topic doesn't exist, returns ``NOT_FOUND``.
+        If the subscription already exists, raises ``ALREADY_EXISTS``.
+        If the corresponding topic doesn't exist, raises ``NOT_FOUND``.
 
         If the name is not provided in the request, the server will
         assign a random name for this subscription on the same project
@@ -1952,8 +1952,8 @@ class SubscriberClient(metaclass=SubscriberClientMeta):
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-        If the snapshot already exists, returns ``ALREADY_EXISTS``. If
-        the requested subscription doesn't exist, returns ``NOT_FOUND``.
+        If the snapshot already exists, raises ``ALREADY_EXISTS``. If
+        the requested subscription doesn't exist, raises ``NOT_FOUND``.
         If the backlog in the subscription is too old -- and the
         resulting snapshot would expire in less than 1 hour -- then
         ``FAILED_PRECONDITION`` is returned. See also the

--- a/google/pubsub_v1/services/subscriber/transports/grpc.py
+++ b/google/pubsub_v1/services/subscriber/transports/grpc.py
@@ -246,8 +246,8 @@ class SubscriberGrpcTransport(SubscriberTransport):
         Creates a subscription to a given topic. See the [resource name
         rules]
         (https://cloud.google.com/pubsub/docs/pubsub-basics#resource_names).
-        If the subscription already exists, returns ``ALREADY_EXISTS``.
-        If the corresponding topic doesn't exist, returns ``NOT_FOUND``.
+        If the subscription already exists, raises ``ALREADY_EXISTS``.
+        If the corresponding topic doesn't exist, raises ``NOT_FOUND``.
 
         If the name is not provided in the request, the server will
         assign a random name for this subscription on the same project
@@ -608,8 +608,8 @@ class SubscriberGrpcTransport(SubscriberTransport):
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-        If the snapshot already exists, returns ``ALREADY_EXISTS``. If
-        the requested subscription doesn't exist, returns ``NOT_FOUND``.
+        If the snapshot already exists, raises ``ALREADY_EXISTS``. If
+        the requested subscription doesn't exist, raises ``NOT_FOUND``.
         If the backlog in the subscription is too old -- and the
         resulting snapshot would expire in less than 1 hour -- then
         ``FAILED_PRECONDITION`` is returned. See also the

--- a/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
+++ b/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
@@ -249,8 +249,8 @@ class SubscriberGrpcAsyncIOTransport(SubscriberTransport):
         Creates a subscription to a given topic. See the [resource name
         rules]
         (https://cloud.google.com/pubsub/docs/pubsub-basics#resource_names).
-        If the subscription already exists, returns ``ALREADY_EXISTS``.
-        If the corresponding topic doesn't exist, returns ``NOT_FOUND``.
+        If the subscription already exists, raises ``ALREADY_EXISTS``.
+        If the corresponding topic doesn't exist, raises ``NOT_FOUND``.
 
         If the name is not provided in the request, the server will
         assign a random name for this subscription on the same project
@@ -621,8 +621,8 @@ class SubscriberGrpcAsyncIOTransport(SubscriberTransport):
         operations, which allow you to manage message acknowledgments in
         bulk. That is, you can set the acknowledgment state of messages
         in an existing subscription to the state captured by a snapshot.
-        If the snapshot already exists, returns ``ALREADY_EXISTS``. If
-        the requested subscription doesn't exist, returns ``NOT_FOUND``.
+        If the snapshot already exists, raises ``ALREADY_EXISTS``. If
+        the requested subscription doesn't exist, raises ``NOT_FOUND``.
         If the backlog in the subscription is too old -- and the
         resulting snapshot would expire in less than 1 hour -- then
         ``FAILED_PRECONDITION`` is returned. See also the


### PR DESCRIPTION
Improves docstrings on the following modules, by replacing `returns` with `raises`:
- google/pubsub_v1/services/subscriber/async_client.py
- google/pubsub_v1/services/subscriber/client.py
- google/pubsub_v1/services/subscriber/transports/grpc.py
- google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py

Fixes #1020 🦕


