### PR TITLE
build: treat warnings as errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,18 @@
+[pytest]
+filterwarnings =
+    # treat all warnings as errors
+    error
+    # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed
+    ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
+    # Remove once https://github.com/googleapis/python-api-common-protos/pull/191 is merged
+    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
+    ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
+    # Remove once release PR https://github.com/googleapis/proto-plus-python/pull/391 is merged
+    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:proto.datetime_helpers
+    ignore: Releasing a message that was never added or already released:RuntimeWarning
+    # Remove once release PR https://github.com/googleapis/python-api-core/pull/555 is merged
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:google.api_core.datetime_helpers
+    # Remove once https://github.com/grpc/grpc/issues/35086 is fixed
+    ignore:There is no current event loop:DeprecationWarning:grpc.aio._channel
+    # Remove once a version of grpcio newer than 1.59.3 is released to PyPI
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:grpc._channel

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,6 @@ filterwarnings =
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
     # Remove once release PR https://github.com/googleapis/proto-plus-python/pull/391 is merged
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:proto.datetime_helpers
-    ignore: Releasing a message that was never added or already released:RuntimeWarning
     # Remove once release PR https://github.com/googleapis/python-api-core/pull/555 is merged
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:google.api_core.datetime_helpers
     # Remove once https://github.com/grpc/grpc/issues/35086 is fixed

--- a/samples/snippets/schema.py
+++ b/samples/snippets/schema.py
@@ -473,7 +473,8 @@ def publish_avro_records(project_id: str, topic_id: str, avsc_file: str) -> None
     topic_path = publisher_client.topic_path(project_id, topic_id)
 
     # Prepare to write Avro records to the binary output stream.
-    avro_schema = schema.parse(open(avsc_file, "rb").read())
+    with open(avsc_file, "rb") as file:
+        avro_schema = schema.parse(file.read())
     writer = DatumWriter(avro_schema)
     bout = io.BytesIO()
 
@@ -579,7 +580,8 @@ def subscribe_with_avro_schema(
     subscriber = SubscriberClient()
     subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
-    avro_schema = schema.parse(open(avsc_file, "rb").read())
+    with open(avsc_file, "rb") as file:
+        avro_schema = schema.parse(file.read())
 
     def callback(message: pubsub_v1.subscriber.message.Message) -> None:
         # Get the message serialization type.
@@ -642,7 +644,8 @@ def subscribe_with_avro_schema_with_revisions(
     subscriber = SubscriberClient()
     subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
-    writer_avro_schema = schema.parse(open(avsc_file, "rb").read())
+    with open(avsc_file, "rb") as file:
+        writer_avro_schema = schema.parse(file.read())
     # Dict to keep readers for different schema revisions.
     revisions_to_readers = {}
 

--- a/tests/unit/gapic/pubsub_v1/test_subscriber.py
+++ b/tests/unit/gapic/pubsub_v1/test_subscriber.py
@@ -2888,7 +2888,6 @@ def test_pull_flattened_error():
         client.pull(
             pubsub.PullRequest(),
             subscription="subscription_value",
-            return_immediately=True,
             max_messages=1277,
         )
 
@@ -2942,7 +2941,6 @@ async def test_pull_flattened_error_async():
         await client.pull(
             pubsub.PullRequest(),
             subscription="subscription_value",
-            return_immediately=True,
             max_messages=1277,
         )
 
@@ -6993,7 +6991,6 @@ def test_pull_rest_flattened():
         # get truthy value for each flattened field
         mock_args = dict(
             subscription="subscription_value",
-            return_immediately=True,
             max_messages=1277,
         )
         mock_args.update(sample_request)
@@ -7032,7 +7029,6 @@ def test_pull_rest_flattened_error(transport: str = "rest"):
         client.pull(
             pubsub.PullRequest(),
             subscription="subscription_value",
-            return_immediately=True,
             max_messages=1277,
         )
 

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -19,7 +19,6 @@ import time
 from typing import Callable
 from typing import Sequence
 from typing import Union
-import warnings
 
 import pytest
 

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -179,7 +179,9 @@ def test_incorrectly_releasing_too_many_messages():
     msg3 = grpc_types.PubsubMessage(data=b"z" * 100)
 
     # Releasing a message that would make the load negative should result in a warning.
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        RuntimeWarning, match="Releasing a message that was never added or already released"
+    ) as warned:
         flow_controller.release(msg1)
 
     assert len(warned) == 1
@@ -438,7 +440,9 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
     assert reservation is not None, "No messages blocked by flow controller."
     reservation.bytes_reserved = reservation.bytes_needed + 1
 
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        RuntimeWarning, match="Too many bytes reserved."
+    ) as warned:
         _run_in_daemon(flow_controller.release, [msg1], releasing_1_done)
         if not releasing_1_done.wait(timeout=0.1):
             pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER

--- a/tests/unit/pubsub_v1/publisher/test_flow_controller.py
+++ b/tests/unit/pubsub_v1/publisher/test_flow_controller.py
@@ -180,7 +180,8 @@ def test_incorrectly_releasing_too_many_messages():
 
     # Releasing a message that would make the load negative should result in a warning.
     with pytest.warns(
-        RuntimeWarning, match="Releasing a message that was never added or already released"
+        RuntimeWarning,
+        match="Releasing a message that was never added or already released",
     ) as warned:
         flow_controller.release(msg1)
 
@@ -440,9 +441,7 @@ def test_warning_on_internal_reservation_stats_error_when_unblocking():
     assert reservation is not None, "No messages blocked by flow controller."
     reservation.bytes_reserved = reservation.bytes_needed + 1
 
-    with pytest.warns(
-        RuntimeWarning, match="Too many bytes reserved."
-    ) as warned:
+    with pytest.warns(RuntimeWarning, match="Too many bytes reserved.") as warned:
         _run_in_daemon(flow_controller.release, [msg1], releasing_1_done)
         if not releasing_1_done.wait(timeout=0.1):
             pytest.fail("Releasing a message blocked or errored.")  # pragma: NO COVER

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -60,9 +60,7 @@ def _assert_retries_equal(retry, retry2):
 def test_api_property_deprecated(creds):
     client = publisher.Client(credentials=creds)
 
-    with pytest.warns(
-        DeprecationWarning, match="client.api"
-    ) as warned:
+    with pytest.warns(DeprecationWarning, match="client.api") as warned:
         client.api
 
     assert len(warned) == 1
@@ -74,9 +72,7 @@ def test_api_property_deprecated(creds):
 def test_api_property_proxy_to_generated_client(creds):
     client = publisher.Client(credentials=creds)
 
-    with pytest.warns(
-        DeprecationWarning, match="client.api"
-    ) as warned:
+    with pytest.warns(DeprecationWarning, match="client.api") as warned:
         api_object = client.api
 
     # Not a perfect check, but we are satisficed if the returned API object indeed

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -28,7 +28,6 @@ else:
 
 import pytest
 import time
-import warnings
 
 from google.api_core import gapic_v1
 from google.api_core import retry as retries
@@ -72,7 +71,7 @@ def test_api_property_deprecated(creds):
 def test_api_property_proxy_to_generated_client(creds):
     client = publisher.Client(credentials=creds)
 
-    with pytest.warns(DeprecationWarning, match="client.api") as warned:
+    with pytest.warns(DeprecationWarning, match="client.api"):
         api_object = client.api
 
     # Not a perfect check, but we are satisficed if the returned API object indeed

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -60,7 +60,9 @@ def _assert_retries_equal(retry, retry2):
 def test_api_property_deprecated(creds):
     client = publisher.Client(credentials=creds)
 
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        DeprecationWarning, match="client.api"
+    ) as warned:
         client.api
 
     assert len(warned) == 1
@@ -72,7 +74,9 @@ def test_api_property_deprecated(creds):
 def test_api_property_proxy_to_generated_client(creds):
     client = publisher.Client(credentials=creds)
 
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(
+        DeprecationWarning, match="client.api"
+    ) as warned:
         api_object = client.api
 
     # Not a perfect check, but we are satisficed if the returned API object indeed

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -361,9 +361,7 @@ def test_unknown_request_type():
 
     items = ["a random string, not a known request type"]
     manager.send_unary_ack.return_value = (items, [])
-    with pytest.warns(
-        RuntimeWarning, match="Skipping unknown request item of type"
-    ):
+    with pytest.warns(RuntimeWarning, match="Skipping unknown request item of type"):
         dispatcher_.dispatch_callback(items)
 
 

--- a/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -361,7 +361,10 @@ def test_unknown_request_type():
 
     items = ["a random string, not a known request type"]
     manager.send_unary_ack.return_value = (items, [])
-    dispatcher_.dispatch_callback(items)
+    with pytest.warns(
+        RuntimeWarning, match="Skipping unknown request item of type"
+    ):
+        dispatcher_.dispatch_callback(items)
 
 
 def test_ack():

--- a/tests/unit/pubsub_v1/subscriber/test_scheduler.py
+++ b/tests/unit/pubsub_v1/subscriber/test_scheduler.py
@@ -14,10 +14,10 @@
 
 import concurrent.futures
 import queue
+import pytest
 import sys
 import threading
 import time
-import warnings
 
 # special case python < 3.8
 if sys.version_info.major == 3 and sys.version_info.minor < 8:
@@ -76,7 +76,9 @@ def test_schedule_after_executor_shutdown_warning():
     scheduler_.schedule(callback, "arg1", kwarg1="meep")
     scheduler_._executor.shutdown()
 
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        RuntimeWarning, match="Scheduling a callback after executor shutdown"
+    ) as warned:
         scheduler_.schedule(callback, "arg2", kwarg2="boop")
 
     assert len(warned) == 1

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -218,7 +218,9 @@ def test_context_manager_raises_if_closed(creds):
 def test_api_property_deprecated(creds):
     client = subscriber.Client(credentials=creds)
 
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        DeprecationWarning, match="client.api"
+    ) as warned:
         client.api
 
     assert len(warned) == 1
@@ -230,7 +232,9 @@ def test_api_property_deprecated(creds):
 def test_api_property_proxy_to_generated_client(creds):
     client = subscriber.Client(credentials=creds)
 
-    with warnings.catch_warnings(record=True):
+    with pytest.warns(
+        DeprecationWarning, match="client.api"
+    ) as warned:
         api_object = client.api
 
     # Not a perfect check, but we are satisficed if the returned API object indeed
@@ -264,7 +268,7 @@ def test_sync_pull_warning_if_return_immediately(creds):
 
     with mock.patch.object(
         client._transport, "_wrapped_methods"
-    ), warnings.catch_warnings(record=True) as warned:
+    ), pytest.warns(DeprecationWarning, match="The return_immediately flag is deprecated and should be set to False") as warned:
         client.pull(subscription=subscription_path, return_immediately=True)
 
     # Setting the deprecated return_immediately flag to True should emit a warning.
@@ -287,7 +291,7 @@ async def test_sync_pull_warning_if_return_immediately_async(creds):
         new=mock.AsyncMock,
     )
 
-    with patcher, warnings.catch_warnings(record=True) as warned:
+    with patcher, pytest.warns(DeprecationWarning, match="The return_immediately flag is deprecated and should be set to False") as warned:
         await client.pull(subscription=subscription_path, return_immediately=True)
 
     # Setting the deprecated return_immediately flag to True should emit a warning.

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import sys
-import warnings
 
 import grpc
 
@@ -230,7 +229,7 @@ def test_api_property_deprecated(creds):
 def test_api_property_proxy_to_generated_client(creds):
     client = subscriber.Client(credentials=creds)
 
-    with pytest.warns(DeprecationWarning, match="client.api") as warned:
+    with pytest.warns(DeprecationWarning, match="client.api"):
         api_object = client.api
 
     # Not a perfect check, but we are satisficed if the returned API object indeed

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -218,9 +218,7 @@ def test_context_manager_raises_if_closed(creds):
 def test_api_property_deprecated(creds):
     client = subscriber.Client(credentials=creds)
 
-    with pytest.warns(
-        DeprecationWarning, match="client.api"
-    ) as warned:
+    with pytest.warns(DeprecationWarning, match="client.api") as warned:
         client.api
 
     assert len(warned) == 1
@@ -232,9 +230,7 @@ def test_api_property_deprecated(creds):
 def test_api_property_proxy_to_generated_client(creds):
     client = subscriber.Client(credentials=creds)
 
-    with pytest.warns(
-        DeprecationWarning, match="client.api"
-    ) as warned:
+    with pytest.warns(DeprecationWarning, match="client.api") as warned:
         api_object = client.api
 
     # Not a perfect check, but we are satisficed if the returned API object indeed
@@ -266,9 +262,10 @@ def test_sync_pull_warning_if_return_immediately(creds):
     client = subscriber.Client(credentials=creds)
     subscription_path = "projects/foo/subscriptions/bar"
 
-    with mock.patch.object(
-        client._transport, "_wrapped_methods"
-    ), pytest.warns(DeprecationWarning, match="The return_immediately flag is deprecated and should be set to False") as warned:
+    with mock.patch.object(client._transport, "_wrapped_methods"), pytest.warns(
+        DeprecationWarning,
+        match="The return_immediately flag is deprecated and should be set to False",
+    ) as warned:
         client.pull(subscription=subscription_path, return_immediately=True)
 
     # Setting the deprecated return_immediately flag to True should emit a warning.
@@ -291,7 +288,10 @@ async def test_sync_pull_warning_if_return_immediately_async(creds):
         new=mock.AsyncMock,
     )
 
-    with patcher, pytest.warns(DeprecationWarning, match="The return_immediately flag is deprecated and should be set to False") as warned:
+    with patcher, pytest.warns(
+        DeprecationWarning,
+        match="The return_immediately flag is deprecated and should be set to False",
+    ) as warned:
         await client.pull(subscription=subscription_path, return_immediately=True)
 
     # Setting the deprecated return_immediately flag to True should emit a warning.


### PR DESCRIPTION
This PR adds a `pytest.ini` to treat warnings as errors.

I also included some simple fixes. Let me know if these should be pulled out into separate PRs with corresponding issues created.