### PR TITLE
fix: add google-auth as a direct dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ else:
 dependencies = [
     "grpcio >= 1.51.3, < 2.0dev",  # https://github.com/googleapis/python-pubsub/issues/609
     # google-api-core >= 1.34.0 is allowed in order to support google-api-core 1.x
+    "google-auth >= 2.14.1, <3.0.0dev",
     "google-api-core[grpc] >= 1.34.0, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
     "proto-plus >= 1.22.0, <2.0.0dev",
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -5,6 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.0
+google-auth==2.14.1
 proto-plus==1.22.0
 protobuf==3.19.5
 grpc-google-iam-v1==0.12.4


### PR DESCRIPTION
1. One of the issues this solves is the test coverage failures in https://github.com/googleapis/python-pubsub/actions/runs/7836080724/job/21382924522?pr=1064
2. pulling the google-auth dependency transitively through google-api-core so we decided to use the same `google-auth` version as `google-api-core` which is `2.14.1`
https://github.com/googleapis/python-api-core/blob/82c31184168d92a88ea570780082ab1176cfed53/setup.py#L34
3. Reference PR: https://github.com/googleapis/python-bigquery-storage/pull/740


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
