### PR TITLE
fix: Suppress warnings caused during pytest runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,6 @@ filterwarnings =
     ignore:get_mtls_endpoint_and_cert_source is deprecated.:DeprecationWarning
     # Remove warning once https://github.com/grpc/grpc/issues/35974 is fixed
     ignore:unclosed:ResourceWarning
+    # Added to suppress "DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html"
+    # Remove warning once https://github.com/googleapis/python-pubsub/issues/1187 is fixed.
+    ignore::DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,5 +15,6 @@ filterwarnings =
     # Remove warning once https://github.com/grpc/grpc/issues/35974 is fixed
     ignore:unclosed:ResourceWarning
     # Added to suppress "DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html"
-    # Remove warning once https://github.com/googleapis/python-pubsub/issues/1187 is fixed.
-    ignore::DeprecationWarning
+    # Remove once the minimum supported version of googleapis-common-protos is 1.62.0
+    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
+    ignore:.*pkg_resources is deprecated as an API:DeprecationWarning


### PR DESCRIPTION
Interim suppression of warnings during pytests.

Fixes #1188 1188 🦕