### PR TITLE
fix: Replace asserts with None checks for graceful shutdown

### DIFF
--- a/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -1104,8 +1104,11 @@ class StreamingPullManager(object):
         )
 
         with self._pause_resume_lock:
-            assert self._scheduler is not None
-            assert self._leaser is not None
+            if self._scheduler is None or self._leaser is None:
+                _LOGGER.debug(
+                    f"self._scheduler={self._scheduler} or self._leaser={self._leaser} is None. Stopping further processing."
+                )
+                return
 
             for received_message in received_messages:
                 if (


### PR DESCRIPTION
There are two code paths that race to set / read the value of `self._scheduler` variable of [streaming_pull_manager](https://github.com/googleapis/python-pubsub/blob/main/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py)


### Code path 1

`future.cancel()`:

https://github.com/googleapis/python-pubsub/blob/5402b621ac09b8d6bb10955048e2c0c610a4f68e/google/cloud/pubsub_v1/subscriber/futures.py#L56-L76

calls

`streaming_pull_manager.close()`:

https://github.com/googleapis/python-pubsub/blob/5402b621ac09b8d6bb10955048e2c0c610a4f68e/google/cloud/pubsub_v1/subscriber/futures.py#L75

which schedules the `_shutdown` method:

https://github.com/googleapis/python-pubsub/blob/5402b621ac09b8d6bb10955048e2c0c610a4f68e/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py#L896-L902

that sets the `self._scheduler` variable to None using a lock `self._closing`:

https://github.com/googleapis/python-pubsub/blob/5402b621ac09b8d6bb10955048e2c0c610a4f68e/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py#L912-L929


### Code Path 2

The streaming_pull_manager's `_on_response` method:

https://github.com/googleapis/python-pubsub/blob/5402b621ac09b8d6bb10955048e2c0c610a4f68e/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py#L1106-L1129 asserts that the `self._scheduler` variable is not None before proceeding to use it for processing further.

Since the two code paths use different locks and are running on different threads, there are times when code path1 sets the `self._scheduler` value to None, while the `_on_response` method is still executing. The assert in the `_on_response` method fails causing an assertion error to be thrown. This happens when the library tries to process streaming pull responses when the library is also being shut down. 

This change replaces the asserts with a None check that would return early and stop processing(same behavior as an assert minus the error being thrown), resulting in a graceful shutdown of the library without red herring errors being logged to the user.



Fixes #997  🦕
