### PR TITLE
fix: Update the requirements.txt for samples directory

### DIFF
--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,8 +1,10 @@
-google-cloud-pubsub==2.23.0
+google-cloud-pubsub==2.25.0
 avro==1.12.0
 protobuf===4.24.4; python_version == '3.7'
 protobuf==5.28.0; python_version >= '3.8'
 avro==1.12.0
-opentelemetry-api==1.22.0
-opentelemetry-sdk==1.22.0
+opentelemetry-api==1.22.0; python_version == '3.7'
+opentelemetry-sdk==1.22.0; python_version == '3.7'
+opentelemetry-api==1.27.0; python_version >= '3.8'
+opentelemetry-sdk==1.27.0; python_version >= '3.8'
 opentelemetry-exporter-gcp-trace==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,10 @@ dependencies = [
     "protobuf>=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     "grpc-google-iam-v1 >= 0.12.4, < 1.0.0dev",
     "grpcio-status >= 1.33.2",
-    "opentelemetry-api",
-    "opentelemetry-sdk",
+    "opentelemetry-api <= 1.22.0; python_version<='3.7'",
+    "opentelemetry-api >= 1.27.0; python_version>='3.8'",
+    "opentelemetry-sdk <= 1.22.0; python_version<='3.7'",
+    "opentelemetry-sdk >= 1.27.0; python_version>='3.8'",
 ]
 extras = {"libcst": "libcst >= 0.3.10"}
 url = "https://github.com/googleapis/python-pubsub"


### PR DESCRIPTION
Add a min required version for open telemetry to avoid issues with unsupported links feature on older versions of opentelemetry.