### PR TITLE
fix: Handle TransportError Exceptions thrown from gapic_publish

### DIFF
--- a/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from opentelemetry import trace
 import google.api_core.exceptions
 from google.api_core import gapic_v1
+from google.auth import exceptions as auth_exceptions
 
 from google.cloud.pubsub_v1.publisher import exceptions
 from google.cloud.pubsub_v1.publisher import futures
@@ -342,7 +343,10 @@ class Batch(base.Batch):
                     )
                     span.set_attribute(key="messaging.message.id", value=message_id)
                     wrapper.end_create_span()
-        except google.api_core.exceptions.GoogleAPIError as exc:
+        except (
+            google.api_core.exceptions.GoogleAPIError,
+            auth_exceptions.TransportError,
+        ) as exc:
             # We failed to publish, even after retries, so set the exception on
             # all futures and exit.
             self._status = base.BatchStatus.ERROR


### PR DESCRIPTION
### Current behavior:

If `TransportError` is thrown by `google.auth` library: 

https://github.com/googleapis/google-auth-library-python/blob/c3ea09fd8b9ee8f094263fdc809c59d9dfaa3124/google/auth/compute_engine/_metadata.py#L187-L189

when doing a `_gapic_publish`:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L322-L327

Then, 

1. The exception is not caught:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L345

2. Status of batch not set to ERROR:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L348

3. Exceptions not set in the publish futures

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L364-L369

4. The thread in which the batch `gapic_publish` was occuring dies without setting the correct batch state / future exceptions:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L237-L239

5. State of Batch remains IN_PROGRESS indefinitely

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L288

6. Subsequent publishes of messages result in creation of a new batch:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L449-L450

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py#L323-L326

7. Messages that were in the batch whose commit thread died:
- Will not have the TransportError set as an exception in their publish futures
- The publish future will either hang or timeout

### Behavior expected with change

1. `TransportError` during `gapic_publish` will be caught in addition to the existing `GoogleAPIError`

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L345

2. Existing behavior when `GoogleAPIError` is caught during `gapic_publish` would also now apply to `TransportError`, i.e:

- Batch status will be set to `ERROR`, future exceptions will be set:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L345-L371

- Subsequent publish of messages on the batch object will cause an `AssertionError`:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_batch/thread.py#L444-L447

which will be bubbled up through the Ordered / Unordered Sequenceer's `publish` method:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py#L321-L328 

to the Publisher client's `publish` method:

https://github.com/googleapis/python-pubsub/blob/f79d35a21a0e005613f1f80f8ad285da5af09abb/google/cloud/pubsub_v1/publisher/client.py#L477-L495

which would bubble the exception back to the user


Additional details can be found here: https://github.com/googleapis/python-pubsub/issues/1173#issuecomment-2453808407



Fixes #1173 🦕
