### PR TITLE
fix: Stop using api_core default timeouts in publish since they are broken

### DIFF
--- a/google/cloud/pubsub_v1/types.py
+++ b/google/cloud/pubsub_v1/types.py
@@ -35,6 +35,7 @@ from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
 
 from google.api_core.protobuf_helpers import get_messages
+from google.api_core.timeout import ConstantTimeout
 
 from google.pubsub_v1.types import pubsub as pubsub_gapic_types
 
@@ -191,7 +192,10 @@ class PublisherOptions(NamedTuple):
         "an instance of :class:`google.api_core.retry.Retry`."
     )
 
-    timeout: "OptionalTimeout" = gapic_v1.method.DEFAULT  # use api_core default
+    # Use ConstantTimeout instead of api_core default because the default
+    # value results in retries with zero deadline.
+    # Refer https://github.com/googleapis/python-api-core/issues/654
+    timeout: "OptionalTimeout" = ConstantTimeout(60)
     (
         "Timeout settings for message publishing by the client. It should be "
         "compatible with :class:`~.pubsub_v1.types.TimeoutType`."


### PR DESCRIPTION
### Change in behavior

Default publish timeout behavior:

Pre-change: 60s timeout for initial RPC, 0s timeout per retry, 600s total timeout
Post-change:60s timeout for initial RPC, 60s timeout per retry, 600s total timeout


### Change

Only non-test / non sample(i.e functional) usage found for `PublisherOptions.timeout` is here:

https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/cloud/pubsub_v1/publisher/client.py#L440-L441

This change in usage is intended.

### Call stack:

https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/cloud/pubsub_v1/publisher/client.py#L299

invokes one of the sequencers(ordered or unordered)

https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/cloud/pubsub_v1/publisher/client.py#L477-L479

which then create a batch with this timeout

https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/cloud/pubsub_v1/publisher/_sequencer/ordered_sequencer.py#L255-L263

which uses it when committing the batch / publishing the messages:

https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/cloud/pubsub_v1/publisher/_batch/thread.py#L323-L328


and invokes gapic_publish: https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/cloud/pubsub_v1/publisher/client.py#L289-L291


which then uses it in the RPC call:
https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/pubsub_v1/services/publisher/client.py#L1067-L1072

that is obtained by wrapping the transport base publish call:

https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/pubsub_v1/services/publisher/client.py#L1055

The wrapper uses the timeout when invoking the GapicCallable:

https://github.com/googleapis/python-api-core/blob/b1fae31c8c71ed65ad22a415dab2b54720c3d4ba/google/api_core/gapic_v1/method.py#L245-L252

which currently overrides float and int timeouts to use TimeToDeadlineTimeout:

https://github.com/googleapis/python-api-core/blob/b1fae31c8c71ed65ad22a415dab2b54720c3d4ba/google/api_core/gapic_v1/method.py#L112-L113

which is incorrect(why its incorrect is mentioned in the attached bug)



Fixes #1325 🦕
