### PR TITLE
chore(revert): Revert "fix: get channel target for a gRPC request"

### DIFF
--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -56,7 +56,8 @@ from google.cloud.pubsub_v1.open_telemetry.publish_message_wrapper import (
 C = TypeVar("C", bound=Callable[..., Any])
 typed_flaky = cast(Callable[[C], C], flaky(max_runs=5, min_passes=1))
 
-# Attempt to use `_thunk` to obtain the underlying grpc channel from 
+
+# Attempt to use `_thunk` to obtain the underlying grpc channel from
 # the intercept channel. Default to obtaining the grpc channel directly
 # for backwards compatibility.
 # TODO(https://github.com/grpc/grpc/issues/38519): Workaround to obtain a channel
@@ -66,6 +67,7 @@ def get_publish_channel(client):
         return client._transport.publish._thunk("")._channel
     except AttributeError:
         return client._transport.publish._channel
+
 
 def _assert_retries_equal(retry, retry2):
     # Retry instances cannot be directly compared, because their predicates are

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -57,14 +57,6 @@ C = TypeVar("C", bound=Callable[..., Any])
 typed_flaky = cast(Callable[[C], C], flaky(max_runs=5, min_passes=1))
 
 
-# NOTE: This interceptor is required to create an intercept channel.
-class _PublisherClientGrpcInterceptor(
-    grpc.UnaryUnaryClientInterceptor,
-):
-    def intercept_unary_unary(self, continuation, client_call_details, request):
-        pass
-
-
 def _assert_retries_equal(retry, retry2):
     # Retry instances cannot be directly compared, because their predicates are
     # different instances of the same function. We thus manually compare their other
@@ -424,27 +416,17 @@ def test_init_client_options_pass_through():
         assert client.transport._ssl_channel_credentials == mock_ssl_creds
 
 
-def test_init_emulator(monkeypatch, creds):
+def test_init_emulator(monkeypatch):
     monkeypatch.setenv("PUBSUB_EMULATOR_HOST", "/foo/bar:123")
     # NOTE: When the emulator host is set, a custom channel will be used, so
     #       no credentials (mock ot otherwise) can be passed in.
-
-    # TODO(https://github.com/grpc/grpc/issues/38519): Workaround to create an intercept
-    # channel (for forwards compatibility) with a channel created by the publisher client
-    # where target is set to the emulator host.
-    channel = publisher.Client().transport.grpc_channel
-    interceptor = _PublisherClientGrpcInterceptor()
-    intercept_channel = grpc.intercept_channel(channel, interceptor)
-    transport = publisher.Client.get_transport_class("grpc")(
-        credentials=creds, channel=intercept_channel
-    )
-    client = publisher.Client(transport=transport)
+    client = publisher.Client()
 
     # Establish that a gRPC request would attempt to hit the emulator host.
     #
     # Sadly, there seems to be no good way to do this without poking at
     # the private API of gRPC.
-    channel = client._transport.publish._thunk("")._channel
+    channel = client._transport.publish._channel
     # Behavior to include dns prefix changed in gRPCv1.63
     grpc_major, grpc_minor = [int(part) for part in grpc.__version__.split(".")[0:2]]
     if grpc_major > 1 or (grpc_major == 1 and grpc_minor >= 63):

--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -56,6 +56,16 @@ from google.cloud.pubsub_v1.open_telemetry.publish_message_wrapper import (
 C = TypeVar("C", bound=Callable[..., Any])
 typed_flaky = cast(Callable[[C], C], flaky(max_runs=5, min_passes=1))
 
+# Attempt to use `_thunk` to obtain the underlying grpc channel from 
+# the intercept channel. Default to obtaining the grpc channel directly
+# for backwards compatibility.
+# TODO(https://github.com/grpc/grpc/issues/38519): Workaround to obtain a channel
+# until a public API is available.
+def get_publish_channel(client):
+    try:
+        return client._transport.publish._thunk("")._channel
+    except AttributeError:
+        return client._transport.publish._channel
 
 def _assert_retries_equal(retry, retry2):
     # Retry instances cannot be directly compared, because their predicates are
@@ -426,7 +436,7 @@ def test_init_emulator(monkeypatch):
     #
     # Sadly, there seems to be no good way to do this without poking at
     # the private API of gRPC.
-    channel = client._transport.publish._channel
+    channel = get_publish_channel(client)
     # Behavior to include dns prefix changed in gRPCv1.63
     grpc_major, grpc_minor = [int(part) for part in grpc.__version__.split(".")[0:2]]
     if grpc_major > 1 or (grpc_major == 1 and grpc_minor >= 63):

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -36,14 +36,6 @@ from google.cloud.pubsub_v1.open_telemetry.context_propagation import (
 from google.pubsub_v1.types import PubsubMessage
 
 
-# NOTE: This interceptor is required to create an intercept channel.
-class _SubscriberClientGrpcInterceptor(
-    grpc.UnaryUnaryClientInterceptor,
-):
-    def intercept_unary_unary(self, continuation, client_call_details, request):
-        pass
-
-
 def test_init_default_client_info(creds):
     client = subscriber.Client(credentials=creds)
 
@@ -127,27 +119,17 @@ def test_init_client_options_pass_through():
         assert client.transport._ssl_channel_credentials == mock_ssl_creds
 
 
-def test_init_emulator(monkeypatch, creds):
+def test_init_emulator(monkeypatch):
     monkeypatch.setenv("PUBSUB_EMULATOR_HOST", "/baz/bacon:123")
     # NOTE: When the emulator host is set, a custom channel will be used, so
     #       no credentials (mock ot otherwise) can be passed in.
-
-    # TODO(https://github.com/grpc/grpc/issues/38519): Workaround to create an intercept
-    # channel (for forwards compatibility) with a channel created by the publisher client
-    # where target is set to the emulator host.
-    channel = subscriber.Client().transport.grpc_channel
-    interceptor = _SubscriberClientGrpcInterceptor()
-    intercept_channel = grpc.intercept_channel(channel, interceptor)
-    transport = subscriber.Client.get_transport_class("grpc")(
-        credentials=creds, channel=intercept_channel
-    )
-    client = subscriber.Client(transport=transport)
+    client = subscriber.Client()
 
     # Establish that a gRPC request would attempt to hit the emulator host.
     #
     # Sadly, there seems to be no good way to do this without poking at
     # the private API of gRPC.
-    channel = client._transport.pull._thunk("")._channel
+    channel = client._transport.pull._channel
     # Behavior to include dns prefix changed in gRPCv1.63
     grpc_major, grpc_minor = [int(part) for part in grpc.__version__.split(".")[0:2]]
     if grpc_major > 1 or (grpc_major == 1 and grpc_minor >= 63):

--- a/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -36,7 +36,7 @@ from google.cloud.pubsub_v1.open_telemetry.context_propagation import (
 from google.pubsub_v1.types import PubsubMessage
 
 
-# Attempt to use `_thunk` to obtain the underlying grpc channel from 
+# Attempt to use `_thunk` to obtain the underlying grpc channel from
 # the intercept channel. Default to obtaining the grpc channel directly
 # for backwards compatibility.
 # TODO(https://github.com/grpc/grpc/issues/38519): Workaround to obtain a channel
@@ -46,6 +46,7 @@ def get_pull_channel(client):
         return client._transport.pull._thunk("")._channel
     except AttributeError:
         return client._transport.pull._channel
+
 
 def test_init_default_client_info(creds):
     client = subscriber.Client(credentials=creds)


### PR DESCRIPTION
Reverts googleapis/python-pubsub#1339

The PR did not apply the fix as intended. Passing down an intercept channel, which is used to create another intercept channel requires us to call thunk twice i.e. to obtain the underlying `grpc_channel`, we'll need to do:

```
channel = client._transport.pull._thunk("")._thunk("")._channel
```

Instead, we'll revert this change and then apply a follow up fix to obtain the underlying channel using the following way (until a more stable, long-term fix is determined):

```
channel = client._transport.pull._thunk("")._channel
```