### PR TITLE
fix: obtain channel from intercept channel

### DIFF
--- a/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -56,6 +56,16 @@ from google.cloud.pubsub_v1.open_telemetry.publish_message_wrapper import (
 C = TypeVar("C", bound=Callable[..., Any])
 typed_flaky = cast(Callable[[C], C], flaky(max_runs=5, min_passes=1))
 
+# Attempt to use `_thunk` to obtain the underlying grpc channel from 
+# the intercept channel. Default to obtaining the grpc channel directly
+# for backwards compatibility.
+# TODO(https://github.com/grpc/grpc/issues/38519): Workaround to obtain a channel
+# until a public API is available.
+def get_publish_channel(client):
+    try:
+        return client._transport.publish._thunk("")._channel
+    except AttributeError:
+        return client._transport.publish._channel
 
 def _assert_retries_equal(retry, retry2):
     # Retry instances cannot be directly compared, because their predicates are
@@ -426,7 +436,7 @@ def test_init_emulator(monkeypatch):
     #
     # Sadly, there seems to be no good way to do this without poking at
     # the private API of gRPC.
-    channel = client._transport.publish._channel
+    channel = get_publish_channel(client)
     # Behavior to include dns prefix changed in gRPCv1.63
     grpc_major, grpc_minor = [int(part) for part in grpc.__version__.split(".")[0:2]]
     if grpc_major > 1 or (grpc_major == 1 and grpc_minor >= 63):


### PR DESCRIPTION
Towards: b/388826364

As per https://github.com/googleapis/python-pubsub/pull/1371, this PR is meant to update the logic for how we obtain the underlying gRPC channel from the intercept channel.