### PR TITLE
fix: allow logs to propagate upstream for caplog testing

### DIFF
--- a/tests/unit/pubsub_v1/conftest.py
+++ b/tests/unit/pubsub_v1/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import pytest
 
 from opentelemetry.sdk.trace import TracerProvider
@@ -43,3 +44,18 @@ def span_exporter():
     provider = trace.get_tracer_provider()
     provider.add_span_processor(processor)
     yield exporter
+
+@pytest.fixture()
+def modify_google_logger_propagation():
+    """
+    Allow propagation of logs to the root logger for tests
+    that depend on the caplog fixture. Restore the default
+    propagation setting after the test finishes.
+    """
+    logger = logging.getLogger("google")
+    original_propagate = logger.propagate
+    logger.propagate = True
+    try:
+        yield
+    finally:
+        logger.propagate = original_propagate

--- a/tests/unit/pubsub_v1/conftest.py
+++ b/tests/unit/pubsub_v1/conftest.py
@@ -45,6 +45,7 @@ def span_exporter():
     provider.add_span_processor(processor)
     yield exporter
 
+
 @pytest.fixture()
 def modify_google_logger_propagation():
     """

--- a/tests/unit/pubsub_v1/subscriber/test_heartbeater.py
+++ b/tests/unit/pubsub_v1/subscriber/test_heartbeater.py
@@ -27,8 +27,7 @@ else:
 
 import pytest
 
-
-def test_heartbeat_inactive_manager_active_rpc(caplog):
+def test_heartbeat_inactive_manager_active_rpc(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager = mock.create_autospec(
@@ -46,7 +45,7 @@ def test_heartbeat_inactive_manager_active_rpc(caplog):
     assert "exiting" in caplog.text
 
 
-def test_heartbeat_inactive_manager_inactive_rpc(caplog):
+def test_heartbeat_inactive_manager_inactive_rpc(caplog, modify_google_logger_propagation,):
     caplog.set_level(logging.DEBUG)
 
     manager = mock.create_autospec(
@@ -64,7 +63,7 @@ def test_heartbeat_inactive_manager_inactive_rpc(caplog):
     assert "exiting" in caplog.text
 
 
-def test_heartbeat_stopped(caplog):
+def test_heartbeat_stopped(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
     manager = mock.create_autospec(
         streaming_pull_manager.StreamingPullManager, instance=True

--- a/tests/unit/pubsub_v1/subscriber/test_heartbeater.py
+++ b/tests/unit/pubsub_v1/subscriber/test_heartbeater.py
@@ -27,7 +27,10 @@ else:
 
 import pytest
 
-def test_heartbeat_inactive_manager_active_rpc(caplog, modify_google_logger_propagation):
+
+def test_heartbeat_inactive_manager_active_rpc(
+    caplog, modify_google_logger_propagation
+):
     caplog.set_level(logging.DEBUG)
 
     manager = mock.create_autospec(
@@ -45,7 +48,10 @@ def test_heartbeat_inactive_manager_active_rpc(caplog, modify_google_logger_prop
     assert "exiting" in caplog.text
 
 
-def test_heartbeat_inactive_manager_inactive_rpc(caplog, modify_google_logger_propagation,):
+def test_heartbeat_inactive_manager_inactive_rpc(
+    caplog,
+    modify_google_logger_propagation,
+):
     caplog.set_level(logging.DEBUG)
 
     manager = mock.create_autospec(

--- a/tests/unit/pubsub_v1/subscriber/test_leaser.py
+++ b/tests/unit/pubsub_v1/subscriber/test_leaser.py
@@ -53,7 +53,7 @@ def test_add_and_remove():
     assert leaser_.bytes == 25
 
 
-def test_add_already_managed(caplog):
+def test_add_already_managed(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     leaser_ = leaser.Leaser(mock.sentinel.manager)
@@ -64,7 +64,7 @@ def test_add_already_managed(caplog):
     assert "already lease managed" in caplog.text
 
 
-def test_remove_not_managed(caplog):
+def test_remove_not_managed(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     leaser_ = leaser.Leaser(mock.sentinel.manager)
@@ -74,7 +74,7 @@ def test_remove_not_managed(caplog):
     assert "not managed" in caplog.text
 
 
-def test_remove_negative_bytes(caplog):
+def test_remove_negative_bytes(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     leaser_ = leaser.Leaser(mock.sentinel.manager)
@@ -98,7 +98,7 @@ def create_manager(flow_control=types.FlowControl()):
     return manager
 
 
-def test_maintain_leases_inactive_manager(caplog):
+def test_maintain_leases_inactive_manager(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
     manager = create_manager()
     manager.is_active = False
@@ -117,7 +117,7 @@ def test_maintain_leases_inactive_manager(caplog):
     assert "exiting" in caplog.text
 
 
-def test_maintain_leases_stopped(caplog):
+def test_maintain_leases_stopped(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
     manager = create_manager()
 

--- a/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
+++ b/tests/unit/pubsub_v1/subscriber/test_messages_on_hold.py
@@ -140,7 +140,7 @@ def test_ordered_messages_one_key():
     assert moh.size == 0
 
 
-def test_ordered_messages_drop_duplicate_keys(caplog):
+def test_ordered_messages_drop_duplicate_keys(caplog, modify_google_logger_propagation):
     moh = messages_on_hold.MessagesOnHold()
 
     msg1 = make_message(ack_id="ack1", ordering_key="key1")
@@ -377,7 +377,7 @@ def test_ordered_and_unordered_messages_interleaved():
     assert moh.size == 0
 
 
-def test_cleanup_nonexistent_key(caplog):
+def test_cleanup_nonexistent_key(caplog, modify_google_logger_propagation):
     moh = messages_on_hold.MessagesOnHold()
     moh._clean_up_ordering_key("non-existent-key")
     assert (
@@ -386,7 +386,7 @@ def test_cleanup_nonexistent_key(caplog):
     )
 
 
-def test_cleanup_key_with_messages(caplog):
+def test_cleanup_key_with_messages(caplog, modify_google_logger_propagation):
     moh = messages_on_hold.MessagesOnHold()
 
     # Put message with "key1".

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -603,7 +603,9 @@ def test__maybe_release_messages_below_overload():
         assert call_args[1].ack_id in ("ack_foo", "ack_bar")
 
 
-def test__maybe_release_messages_negative_on_hold_bytes_warning(caplog, modify_google_logger_propagation):
+def test__maybe_release_messages_negative_on_hold_bytes_warning(
+    caplog, modify_google_logger_propagation
+):
     manager = make_manager(
         flow_control=types.FlowControl(max_messages=10, max_bytes=1000)
     )
@@ -978,7 +980,9 @@ def test_send_unary_modack_api_call_error(caplog, modify_google_logger_propagati
     assert "The front fell off" in caplog.text
 
 
-def test_send_unary_ack_retry_error_exactly_once_disabled_no_futures(caplog, modify_google_logger_propagation):
+def test_send_unary_ack_retry_error_exactly_once_disabled_no_futures(
+    caplog, modify_google_logger_propagation
+):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1014,7 +1018,9 @@ def test_send_unary_ack_retry_error_exactly_once_disabled_no_futures(caplog, mod
     assert "signaled streaming pull manager shutdown" in caplog.text
 
 
-def test_send_unary_ack_retry_error_exactly_once_disabled_with_futures(caplog, modify_google_logger_propagation):
+def test_send_unary_ack_retry_error_exactly_once_disabled_with_futures(
+    caplog, modify_google_logger_propagation
+):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1054,7 +1060,9 @@ def test_send_unary_ack_retry_error_exactly_once_disabled_with_futures(caplog, m
     assert future2.result() == subscriber_exceptions.AcknowledgeStatus.SUCCESS
 
 
-def test_send_unary_ack_retry_error_exactly_once_enabled_no_futures(caplog, modify_google_logger_propagation):
+def test_send_unary_ack_retry_error_exactly_once_enabled_no_futures(
+    caplog, modify_google_logger_propagation
+):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1090,7 +1098,9 @@ def test_send_unary_ack_retry_error_exactly_once_enabled_no_futures(caplog, modi
     assert "signaled streaming pull manager shutdown" in caplog.text
 
 
-def test_send_unary_ack_retry_error_exactly_once_enabled_with_futures(caplog, modify_google_logger_propagation):
+def test_send_unary_ack_retry_error_exactly_once_enabled_with_futures(
+    caplog, modify_google_logger_propagation
+):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1136,7 +1146,9 @@ def test_send_unary_ack_retry_error_exactly_once_enabled_with_futures(caplog, mo
     )
 
 
-def test_send_unary_modack_retry_error_exactly_once_disabled_no_future(caplog, modify_google_logger_propagation):
+def test_send_unary_modack_retry_error_exactly_once_disabled_no_future(
+    caplog, modify_google_logger_propagation
+):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1162,8 +1174,7 @@ def test_send_unary_modack_retry_error_exactly_once_disabled_no_future(caplog, m
 
 
 def test_send_unary_modack_retry_error_exactly_once_disabled_with_futures(
-    caplog,
-    modify_google_logger_propagation
+    caplog, modify_google_logger_propagation
 ):
     caplog.set_level(logging.DEBUG)
 
@@ -1192,8 +1203,7 @@ def test_send_unary_modack_retry_error_exactly_once_disabled_with_futures(
 
 
 def test_send_unary_modack_retry_error_exactly_once_enabled_no_futures(
-    caplog,
-    modify_google_logger_propagation
+    caplog, modify_google_logger_propagation
 ):
     caplog.set_level(logging.DEBUG)
 
@@ -1220,8 +1230,7 @@ def test_send_unary_modack_retry_error_exactly_once_enabled_no_futures(
 
 
 def test_send_unary_modack_retry_error_exactly_once_enabled_with_futures(
-    caplog,
-    modify_google_logger_propagation
+    caplog, modify_google_logger_propagation
 ):
     caplog.set_level(logging.DEBUG)
 
@@ -1274,7 +1283,9 @@ def test_heartbeat_inactive():
     assert not result
 
 
-def test_heartbeat_stream_ack_deadline_seconds(caplog, modify_google_logger_propagation):
+def test_heartbeat_stream_ack_deadline_seconds(
+    caplog, modify_google_logger_propagation
+):
     caplog.set_level(logging.DEBUG)
     manager = make_manager()
     manager._rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
@@ -2090,7 +2101,10 @@ def test__on_response_disable_exactly_once():
     assert manager._stream_ack_deadline == 60
 
 
-def test__on_response_exactly_once_immediate_modacks_fail(caplog, modify_google_logger_propagation,):
+def test__on_response_exactly_once_immediate_modacks_fail(
+    caplog,
+    modify_google_logger_propagation,
+):
     manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
     manager._callback = mock.sentinel.callback
 
@@ -2162,7 +2176,9 @@ def test__on_response_exactly_once_immediate_modacks_fail(caplog, modify_google_
     assert manager.load == 0.001
 
 
-def test__on_response_exactly_once_immediate_modacks_fail_non_invalid(caplog, modify_google_logger_propagation):
+def test__on_response_exactly_once_immediate_modacks_fail_non_invalid(
+    caplog, modify_google_logger_propagation
+):
     manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
     manager._callback = mock.sentinel.callback
 

--- a/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -603,7 +603,7 @@ def test__maybe_release_messages_below_overload():
         assert call_args[1].ack_id in ("ack_foo", "ack_bar")
 
 
-def test__maybe_release_messages_negative_on_hold_bytes_warning(caplog):
+def test__maybe_release_messages_negative_on_hold_bytes_warning(caplog, modify_google_logger_propagation):
     manager = make_manager(
         flow_control=types.FlowControl(max_messages=10, max_bytes=1000)
     )
@@ -924,7 +924,7 @@ def test_send_unary_modack_exactly_once_disabled_with_futures():
     assert future3.result() == subscriber_exceptions.AcknowledgeStatus.SUCCESS
 
 
-def test_send_unary_ack_api_call_error(caplog):
+def test_send_unary_ack_api_call_error(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager = make_manager()
@@ -945,7 +945,7 @@ def test_send_unary_ack_api_call_error(caplog):
     assert "The front fell off" in caplog.text
 
 
-def test_send_unary_modack_api_call_error(caplog):
+def test_send_unary_modack_api_call_error(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager = make_manager()
@@ -978,7 +978,7 @@ def test_send_unary_modack_api_call_error(caplog):
     assert "The front fell off" in caplog.text
 
 
-def test_send_unary_ack_retry_error_exactly_once_disabled_no_futures(caplog):
+def test_send_unary_ack_retry_error_exactly_once_disabled_no_futures(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1014,7 +1014,7 @@ def test_send_unary_ack_retry_error_exactly_once_disabled_no_futures(caplog):
     assert "signaled streaming pull manager shutdown" in caplog.text
 
 
-def test_send_unary_ack_retry_error_exactly_once_disabled_with_futures(caplog):
+def test_send_unary_ack_retry_error_exactly_once_disabled_with_futures(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1054,7 +1054,7 @@ def test_send_unary_ack_retry_error_exactly_once_disabled_with_futures(caplog):
     assert future2.result() == subscriber_exceptions.AcknowledgeStatus.SUCCESS
 
 
-def test_send_unary_ack_retry_error_exactly_once_enabled_no_futures(caplog):
+def test_send_unary_ack_retry_error_exactly_once_enabled_no_futures(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1090,7 +1090,7 @@ def test_send_unary_ack_retry_error_exactly_once_enabled_no_futures(caplog):
     assert "signaled streaming pull manager shutdown" in caplog.text
 
 
-def test_send_unary_ack_retry_error_exactly_once_enabled_with_futures(caplog):
+def test_send_unary_ack_retry_error_exactly_once_enabled_with_futures(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1136,7 +1136,7 @@ def test_send_unary_ack_retry_error_exactly_once_enabled_with_futures(caplog):
     )
 
 
-def test_send_unary_modack_retry_error_exactly_once_disabled_no_future(caplog):
+def test_send_unary_modack_retry_error_exactly_once_disabled_no_future(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager, _, _, _, _, _ = make_running_manager()
@@ -1163,6 +1163,7 @@ def test_send_unary_modack_retry_error_exactly_once_disabled_no_future(caplog):
 
 def test_send_unary_modack_retry_error_exactly_once_disabled_with_futures(
     caplog,
+    modify_google_logger_propagation
 ):
     caplog.set_level(logging.DEBUG)
 
@@ -1192,6 +1193,7 @@ def test_send_unary_modack_retry_error_exactly_once_disabled_with_futures(
 
 def test_send_unary_modack_retry_error_exactly_once_enabled_no_futures(
     caplog,
+    modify_google_logger_propagation
 ):
     caplog.set_level(logging.DEBUG)
 
@@ -1219,6 +1221,7 @@ def test_send_unary_modack_retry_error_exactly_once_enabled_no_futures(
 
 def test_send_unary_modack_retry_error_exactly_once_enabled_with_futures(
     caplog,
+    modify_google_logger_propagation
 ):
     caplog.set_level(logging.DEBUG)
 
@@ -1271,7 +1274,7 @@ def test_heartbeat_inactive():
     assert not result
 
 
-def test_heartbeat_stream_ack_deadline_seconds(caplog):
+def test_heartbeat_stream_ack_deadline_seconds(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
     manager = make_manager()
     manager._rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
@@ -1922,7 +1925,7 @@ def test__on_response_with_leaser_overload():
             assert msg.message_id in ("2", "3")
 
 
-def test__on_response_none_data(caplog):
+def test__on_response_none_data(caplog, modify_google_logger_propagation):
     caplog.set_level(logging.DEBUG)
 
     manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
@@ -2087,7 +2090,7 @@ def test__on_response_disable_exactly_once():
     assert manager._stream_ack_deadline == 60
 
 
-def test__on_response_exactly_once_immediate_modacks_fail(caplog):
+def test__on_response_exactly_once_immediate_modacks_fail(caplog, modify_google_logger_propagation,):
     manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
     manager._callback = mock.sentinel.callback
 
@@ -2159,7 +2162,7 @@ def test__on_response_exactly_once_immediate_modacks_fail(caplog):
     assert manager.load == 0.001
 
 
-def test__on_response_exactly_once_immediate_modacks_fail_non_invalid(caplog):
+def test__on_response_exactly_once_immediate_modacks_fail_non_invalid(caplog, modify_google_logger_propagation):
     manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
     manager._callback = mock.sentinel.callback
 


### PR DESCRIPTION
When tests are run in parallel and a base logger is not configured, then the log propagation from the base logger (i.e. a `google` named logger) to the root logger is disabled (this happens during client construction):

```python3
logger = logging.getLogger("google")
logger.propagate = False
```

Given that the above is a global config, any of the tests that use the caplog fixture start to fail once the propagation of logs to the root logger is disabled. This means that nothing is captured for a logger (by caplog) if it does not propagate to the root logger. See https://github.com/pytest-dev/pytest/issues/3697.

As a workaround, we can allow propagation of logs to the root logger for a test run and then revert it to the original value once the test completes.

Fixes: b/388826364

Note: By default, log propagation to the root logger is disabled. This behaviour is captured in the `README`.