### PR TITLE
chore(deps): pin bigquery library version for python<3.9

### DIFF
--- a/samples/snippets/requirements-test.txt
+++ b/samples/snippets/requirements-test.txt
@@ -3,6 +3,6 @@ pytest===7.4.4; python_version == '3.7'
 pytest==8.3.5; python_version >= '3.8'
 mock==5.2.0
 flaky==3.8.1
-google-cloud-bigquery==3.30.0; python_version < '3.9'
+google-cloud-bigquery===3.30.0; python_version < '3.9'
 google-cloud-bigquery==3.33.0; python_version >= '3.9'
 google-cloud-storage==3.1.0


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

This prevents the issue observed in [PR 1413](https://github.com/googleapis/python-pubsub/pull/1413) where `google-cloud-bigquery` is mistakenly upgraded to a version python<3.9 is incompatible with.
