### PR TITLE
chore: update owlbot post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python:latest
-  digest: sha256:25de45b58e52021d3a24a6273964371a97a4efeefe6ad3845a64e697c63b6447
-# created: 2025-04-14T14:34:43.260858345Z
+  digest: sha256:4a9e5d44b98e8672e2037ee22bc6b4f8e844a2d75fcb78ea8a4b38510112abc6
+# created: 2025-10-07

--- a/owlbot.py
+++ b/owlbot.py
@@ -343,7 +343,7 @@ templated_files = gcp.CommonTemplates().py_library(
     system_test_python_versions=["3.12"],
     system_test_external_dependencies=["psutil","flaky"],
 )
-s.move(templated_files, excludes=[".coveragerc", ".github/blunderbuss.yml", ".github/release-please.yml", "README.rst", "docs/index.rst"])
+s.move(templated_files, excludes=[".coveragerc", ".github/**", "README.rst", "docs/**", ".kokoro/**"])
 
 python.py_samples(skip_readmes=True)
 


### PR DESCRIPTION
- also exclude templated files in [.github](https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/python_library/.github), [.kokoro](https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/python_library/.kokoro) and [docs](https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/python_library/docs)

To find the latest SHA (eg. `4a9e5d44b98e8672e2037ee22bc6b4f8e844a2d75fcb78ea8a4b38510112abc6`), run
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```
```
latest: Pulling from cloud-devrel-public-resources/owlbot-python
Digest: sha256:4a9e5d44b98e8672e2037ee22bc6b4f8e844a2d75fcb78ea8a4b38510112abc6
Status: Image is up to date for gcr.io/cloud-devrel-public-resources/owlbot-python:latest
gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```

```
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```

```
[gcr.io/cloud-devrel-public-resources/owlbot-python@sha256:4a9e5d44b98e8672e2037ee22bc6b4f8e844a2d75fcb78ea8a4b38510112abc6]
```