### PR TITLE
chore: librarian release pull request: 20251015T085412Z

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,0 +1,6 @@
+global_files_allowlist:
+  # Allow the container to read and write the root `CHANGELOG.md`
+  # file during the `release` step to update the latest client library
+  # versions which are hardcoded in the file.
+  - path: "CHANGELOG.md"
+    permissions: "read-write"

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,6 +1,6 @@
 image: python-librarian-generator:latest
 libraries:
-  - id: python-pubsub
+  - id: google-cloud-pubsub
     version: 2.31.1
     last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
     apis: []

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: python-librarian-generator:latest
 libraries:
   - id: google-cloud-pubsub
-    version: 2.31.1
+    version: 2.32.0
     last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
     apis: []
     source_roots:

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,0 +1,14 @@
+image: python-librarian-generator:latest
+libraries:
+  - id: python-pubsub
+    version: 2.42.0
+    last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
+    apis: []
+    source_roots:
+      - google/pubsub
+      - google/cloud
+      - google/pubsub_v1
+    preserve_regex:
+      - .*
+    remove_regex: []
+    tag_format: v{version}

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: python-librarian-generator:latest
 libraries:
   - id: python-pubsub
-    version: 2.42.0
+    version: 2.31.1
     last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-cloud-pubsub/#history
 
+## [2.32.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-pubsub-v2.31.1...google-cloud-pubsub-v2.32.0) (2025-10-15)
+
+
+### Features
+
+* support the protocol version in StreamingPullRequest (#1455)  ([e6294a1883abf9809cb56d5cd4ad25cc501bc994](https://github.com/googleapis/google-cloud-python/commit/e6294a1883abf9809cb56d5cd4ad25cc501bc994))
+* debug logs (#1460)  ([b5d4a458ca9319bebbe3142a1f05d4d4471c8d4d](https://github.com/googleapis/google-cloud-python/commit/b5d4a458ca9319bebbe3142a1f05d4d4471c8d4d))
+
 
 ## [2.31.1](https://github.com/googleapis/python-pubsub/compare/v2.31.0...v2.31.1) (2025-07-28)
 

--- a/google/pubsub/gapic_version.py
+++ b/google/pubsub/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.31.1"  # {x-release-please-version}
+__version__ = "2.32.0"  # {x-release-please-version}

--- a/google/pubsub_v1/gapic_version.py
+++ b/google/pubsub_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.31.1"  # {x-release-please-version}
+__version__ = "2.32.0"  # {x-release-please-version}


### PR DESCRIPTION
Librarian Version: v0.4.1-0.20251014214441-7eee2b5b7fbe
Language Image: python-librarian-generator:latest
<details><summary>google-cloud-pubsub: 2.32.0</summary>

## [2.32.0](https://github.com/googleapis/python-pubsub/compare/v2.31.1...v2.32.0) (2025-10-15)

### Features

* support the protocol version in StreamingPullRequest (#1455) ([e6294a1](https://github.com/googleapis/python-pubsub/commit/e6294a1))

* debug logs (#1460) ([b5d4a45](https://github.com/googleapis/python-pubsub/commit/b5d4a45))

### Miscellaneous Chores

* update all dependencies (#1456) ([1e534de](https://github.com/googleapis/python-pubsub/commit/1e534de))

</details>