### PR TITLE
chore(librarian): specify all generated files in remove_regex

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2,7 +2,7 @@ image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-li
 libraries:
   - id: google-cloud-pubsub
     version: 2.33.0
-    last_generated_commit: fee5b32df810adbd07d6a20bd97d9239937ef6e4
+    last_generated_commit: 9fcfbea0aa5b50fa22e190faceb073d74504172b
     apis:
       - path: google/pubsub/v1
         service_config: pubsub_v1.yaml
@@ -10,7 +10,28 @@ libraries:
       - .
     preserve_regex: []
     remove_regex:
-      - google/pubsub
-      - google/pubsub_v1
-      - tests/unit/gapic
+      - ^google/pubsub
+      - ^google/pubsub_v1
+      - ^tests/unit/gapic
+      - ^tests/__init__.py
+      - ^tests/unit/__init__.py
+      - ^.coveragerc
+      - ^.flake8
+      - ^.pre-commit-config.yaml
+      - ^.repo-metadata.json
+      - ^.trampolinerc
+      - ^LICENSE
+      - ^MANIFEST.in
+      - ^SECURITY.md
+      - ^mypy.ini
+      - ^noxfile.py
+      - ^owlbot.py
+      - ^renovate.json
+      - ^samples/AUTHORING_GUIDE.md
+      - ^samples/CONTRIBUTING.md
+      - ^samples/generated_samples
+      - ^scripts
+      - ^setup.py
+      - ^testing/constraints-3.9
+      - ^testing/constraints-3.1
     tag_format: v{version}

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -30,7 +30,7 @@ libraries:
       - ^samples/AUTHORING_GUIDE.md
       - ^samples/CONTRIBUTING.md
       - ^samples/generated_samples
-      - ^scripts
+      - ^scripts/fixup_pubsub_v1_keywords.py
       - ^setup.py
       - ^testing/constraints-3.9
       - ^testing/constraints-3.1


### PR DESCRIPTION
This PR resolves the following issue when running `librarian generate`. Librarian now prevents generated files from clobbering existing files. All generated files must match `remove_regex` otherwise we will see errors like `file existed in destination`


```
time=2025-11-06T20:18:57.185Z level=INFO msg="=== Docker end ================================================================="
time=2025-11-06T20:18:57.185Z level=INFO msg="cleaning directories" "source roots"=[.]
time=2025-11-06T20:18:57.200Z level=INFO msg="copying library files" id=google-cloud-pubsub destination=/usr/local/google/home/partheniou/git/python-pubsub source=/tmp/librarian-2318048050/output/google-cloud-pubsub
time=2025-11-06T20:18:57.201Z level=ERROR msg="failed to generate library" id=google-cloud-pubsub err="file existed in destination: /usr/local/google/home/partheniou/git/python-pubsub/.coveragerc"
time=2025-11-06T20:18:57.201Z level=INFO msg="generation statistics" all=1 successes=0 skipped=0 failures=1
time=2025-11-06T20:18:57.201Z level=ERROR msg="librarian command failed" err="all 1 libraries failed to generate (skipped: 0)"
```

Command used

```
librarian generate --generate-unchanged
```
