### PR TITLE
chore: librarian release pull request: 20260205T215747Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
 libraries:
   - id: google-cloud-pubsub
-    version: 2.34.0
+    version: 2.35.0
     last_generated_commit: 2d0b3a154fb4f56993487c5409850ad3431a2690
     apis:
       - path: google/pubsub/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 [1]: https://pypi.org/project/google-cloud-pubsub/#history
 
+## [2.35.0](https://github.com/googleapis/python-pubsub/compare/v2.34.0...v2.35.0) (2026-02-05)
+
+
+### Documentation
+
+* A comment for field `topic` in message `.google.pubsub.v1.Subscription` is updated ([07011139f51e4ff195889faf849bd707655e6d46](https://github.com/googleapis/python-pubsub/commit/07011139f51e4ff195889faf849bd707655e6d46))
+* A comment for field `analytics_hub_subscription_info` in message `.google.pubsub.v1.Subscription` is updated ([07011139f51e4ff195889faf849bd707655e6d46](https://github.com/googleapis/python-pubsub/commit/07011139f51e4ff195889faf849bd707655e6d46))
+* A comment for field `subscription` in message `.google.pubsub.v1.CreateSnapshotRequest` is updated ([07011139f51e4ff195889faf849bd707655e6d46](https://github.com/googleapis/python-pubsub/commit/07011139f51e4ff195889faf849bd707655e6d46))
+* add tags documentation links to Pub/Sub resource tags fields ([07011139f51e4ff195889faf849bd707655e6d46](https://github.com/googleapis/python-pubsub/commit/07011139f51e4ff195889faf849bd707655e6d46))
+* Add the IDENTIFIER field behavior annotation to fields of Cloud Pub/Sub methods that represent a specific identity and need to be sourced with additional care ([07011139f51e4ff195889faf849bd707655e6d46](https://github.com/googleapis/python-pubsub/commit/07011139f51e4ff195889faf849bd707655e6d46))
+
+
+### Features
+
+* Add AIInference MessageTransform type ([07011139f51e4ff195889faf849bd707655e6d46](https://github.com/googleapis/python-pubsub/commit/07011139f51e4ff195889faf849bd707655e6d46))
+
 ## [2.34.0](https://github.com/googleapis/python-pubsub/compare/v2.33.0...v2.34.0) (2025-12-16)
 
 

--- a/google/pubsub/gapic_version.py
+++ b/google/pubsub/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.34.0"  # {x-release-please-version}
+__version__ = "2.35.0"  # {x-release-please-version}

--- a/google/pubsub_v1/gapic_version.py
+++ b/google/pubsub_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.34.0"  # {x-release-please-version}
+__version__ = "2.35.0"  # {x-release-please-version}

--- a/samples/generated_samples/snippet_metadata_google.pubsub.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.pubsub.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-pubsub",
-    "version": "2.34.0"
+    "version": "2.35.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
<details><summary>google-cloud-pubsub: 2.35.0</summary>

## [2.35.0](https://github.com/googleapis/python-pubsub/compare/v2.34.0...v2.35.0) (2026-02-05)

### Features

* Add AIInference MessageTransform type (PiperOrigin-RevId: 853856321) ([07011139](https://github.com/googleapis/python-pubsub/commit/07011139))

### Documentation

* A comment for field `analytics_hub_subscription_info` in message `.google.pubsub.v1.Subscription` is updated (PiperOrigin-RevId: 853856321) ([07011139](https://github.com/googleapis/python-pubsub/commit/07011139))

* Add the IDENTIFIER field behavior annotation to fields of Cloud Pub/Sub methods that represent a specific identity and need to be sourced with additional care (PiperOrigin-RevId: 840763233) ([07011139](https://github.com/googleapis/python-pubsub/commit/07011139))

* A comment for field `topic` in message `.google.pubsub.v1.Subscription` is updated (PiperOrigin-RevId: 853856321) ([07011139](https://github.com/googleapis/python-pubsub/commit/07011139))

* A comment for field `subscription` in message `.google.pubsub.v1.CreateSnapshotRequest` is updated (PiperOrigin-RevId: 853856321) ([07011139](https://github.com/googleapis/python-pubsub/commit/07011139))

* add tags documentation links to Pub/Sub resource tags fields (PiperOrigin-RevId: 845891076) ([07011139](https://github.com/googleapis/python-pubsub/commit/07011139))

</details>