### PR TITLE
feat: add support for protobuf <8.0.0

### DIFF
--- a/.librarian/generator-input/setup.py
+++ b/.librarian/generator-input/setup.py
@@ -44,7 +44,7 @@ dependencies = [
     "proto-plus >= 1.22.0, <2.0.0",
     "proto-plus >= 1.22.2, <2.0.0; python_version>='3.11'",
     "proto-plus >= 1.25.0, < 2.0.0; python_version >= '3.13'",
-    "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "protobuf>=3.20.2,<8.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     "grpc-google-iam-v1 >= 0.12.4, < 1.0.0",
     "grpcio-status >= 1.33.2",
     "opentelemetry-api >= 1.27.0",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ dependencies = [
     "proto-plus >= 1.22.0, <2.0.0",
     "proto-plus >= 1.22.2, <2.0.0; python_version>='3.11'",
     "proto-plus >= 1.25.0, < 2.0.0; python_version >= '3.13'",
-    "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "protobuf>=3.20.2,<8.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     "grpc-google-iam-v1 >= 0.12.4, < 1.0.0",
     "grpcio-status >= 1.33.2",
     "opentelemetry-api >= 1.27.0",


### PR DESCRIPTION
## Summary

- Bumps the protobuf upper bound from `<7.0.0` to `<8.0.0` in both `setup.py` and `.librarian/generator-input/setup.py`
- All 1772 unit tests pass with both protobuf 6.x and 7.x

## Test plan

- [x] Ran `tests/unit/` with protobuf 6.33.5 — 1772/1772 passed
- [x] Ran `tests/unit/` with protobuf 7.34.0 — 1772/1772 passed